### PR TITLE
add toggle to control scrcpy video_codec_options parameter

### DIFF
--- a/public/console.html
+++ b/public/console.html
@@ -184,6 +184,10 @@
                             <label class="block text-xs font-medium text-gray-400 mb-1 ml-1" data-i18n="video_codec_options">video_codec_options</label>
                             <input type="text" id="configVideoCodecOptions" class="md-input w-full px-3 py-2 rounded-lg text-white text-sm" placeholder="例如: i-frame-interval=10" data-i18n="codec_options_placeholder">
                         </div>
+                        <div class="flex items-center justify-between py-1">
+                            <label for="configUseVideoCodecOptions" class="text-sm font-medium text-gray-300 cursor-pointer select-none ml-1" data-i18n="use_video_codec_options">携带 video_codec_options 参数</label>
+                            <input type="checkbox" id="configUseVideoCodecOptions" class="md-switch">
+                        </div>
 
                         <div class="flex items-center justify-between py-1">
                             <label for="configAudio" class="text-sm font-medium text-gray-300 cursor-pointer select-none ml-1" data-i18n="audio_enable">启用音频</label>

--- a/public/static/console.js
+++ b/public/static/console.js
@@ -65,6 +65,7 @@ const defaultScrcpyConfig = {
         audio_codec: 'opus',
         video_bit_rate: 8000000,
         video_codec_options: '',
+        use_video_codec_options: 'true',
         new_display: '',
         deviceID: '', // For scrcpy driver to identify which device to connect to
     }
@@ -413,6 +414,7 @@ function startStream(serial) {
                 audio: drv.audio || "true",
                 video_bit_rate: String(drv.video_bit_rate || 8000000),
                 video_codec_options: drv.video_codec_options || '',
+                use_video_codec_options: drv.use_video_codec_options || 'true',
                 new_display: drv.new_display || '',
                 max_size: drv.max_size || '',
                 deviceID: config.device_ip || '', // Pass device IP as deviceID for scrcpy to identify which device to connect to
@@ -487,6 +489,7 @@ function showConfigModal(serial) {
         document.getElementById('configMaxSize').value = drv.max_size || '';
         document.getElementById('configVideoCodec').value = drv.video_codec || 'h264';
         document.getElementById('configVideoCodecOptions').value = drv.video_codec_options || '';
+        document.getElementById('configUseVideoCodecOptions').checked = (drv.use_video_codec_options || 'true') === 'true';
         document.getElementById('configAudio').checked = drv.audio === 'true';
         document.getElementById('configNewDisplay').value = drv.new_display || '';
     }
@@ -526,6 +529,7 @@ function saveDeviceConfig() {
         drv.max_size = document.getElementById('configMaxSize').value.trim() || '';
         drv.video_codec = document.getElementById('configVideoCodec').value;
         drv.video_codec_options = document.getElementById('configVideoCodecOptions').value.trim();
+        drv.use_video_codec_options = document.getElementById('configUseVideoCodecOptions').checked ? 'true' : 'false';
         drv.new_display = document.getElementById('configNewDisplay').value.trim();
         drv.audio = document.getElementById('configAudio').checked ? 'true' : 'false';
         drv.audio_codec = 'opus'; // Hardcoded default for now

--- a/public/static/i18n.js
+++ b/public/static/i18n.js
@@ -61,6 +61,7 @@ const translations = {
         display: "Display (Experimental)",
         config_device_title: "Configure {serial}",
         video_codec_options: "video_codec_options",
+        use_video_codec_options: "Send video_codec_options",
         error_from_server: "Error from server: {msg}",
         call_api_failed: "API request failed",
 
@@ -142,6 +143,7 @@ const translations = {
         display: "显示 (实验性)",
         config_device_title: "配置 {serial}",
         video_codec_options: "video_codec_options",
+        use_video_codec_options: "携带 video_codec_options 参数",
         error_from_server: "服务器错误: {msg}",
         call_api_failed: "API请求失败",
 
@@ -223,6 +225,7 @@ const translations = {
         display: "ディスプレイ (実験的)",
         config_device_title: "{serial} の設定",
         video_codec_options: "video_codec_options",
+        use_video_codec_options: "video_codec_options を送信",
         error_from_server: "サーバーエラー: {msg}",
         call_api_failed: "APIリクエストに失敗しました",
 

--- a/sdriver/scrcpy/driver.go
+++ b/sdriver/scrcpy/driver.go
@@ -263,18 +263,21 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 		video_codec_options = video_codec_options_user
 		log.Printf("Using user-provided video codec options: %s", video_codec_options)
 	}
+	use_video_codec_options := config["use_video_codec_options"]
+	if use_video_codec_options == "" {
+		use_video_codec_options = "true"
+	}
 	options := map[string]string{
-		"CLASSPATH":           SCRCPY_SERVER_ANDROID_DST,
-		"Version":             SCRCPY_VERSION,
-		"scid":                da.scid,
-		"max_size":            strconv.Itoa(max_size),
-		"max_fps":             strconv.Itoa(max_fps),
-		"video":               "true",
-		"video_codec_options": video_codec_options, // bitrate-mode=2 to enable CBR
-		"video_bit_rate":      strconv.Itoa(video_bit_rate),
-		"video_codec":         config["video_codec"],
-		"audio":               config["audio"],
-		"audio_bit_rate":      config["audio_bit_rate"],
+		"CLASSPATH":      SCRCPY_SERVER_ANDROID_DST,
+		"Version":        SCRCPY_VERSION,
+		"scid":           da.scid,
+		"max_size":       strconv.Itoa(max_size),
+		"max_fps":        strconv.Itoa(max_fps),
+		"video":          "true",
+		"video_bit_rate": strconv.Itoa(video_bit_rate),
+		"video_codec":    config["video_codec"],
+		"audio":          config["audio"],
+		"audio_bit_rate": config["audio_bit_rate"],
 		// "audio_codec_options": "durationUs=10000", // 10ms
 		"control":     "true",
 		"new_display": config["new_display"],
@@ -282,6 +285,9 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 		"log_level":   "info",
 
 		// "video_encoder":  "c2.rk.hevc.encoder",
+	}
+	if use_video_codec_options == "true" {
+		options["video_codec_options"] = video_codec_options // bitrate-mode=2 to enable CBR
 	}
 
 	da.adbClient.StartScrcpyServer(options)


### PR DESCRIPTION
Some devices fail to start the scrcpy server regardless of the video_codec_options parameters provided.

Example error logs:

[server] ERROR: Capture/encoding error: android.media.MediaCodec$CodecException: Error 0x80001001
[server] INFO: Retrying with -m1024...
[server] ERROR: Capture/encoding error: android.media.MediaCodec$CodecException: Error 0x80001001
[server] INFO: Retrying with -m800...
[server] ERROR: Capture/encoding error: android.media.MediaCodec$CodecException: Error 0x80001001

This change introduces a toggle to control whether video_codec_options is passed, allowing the scrcpy server to determine its startup parameters and improving compatibility across devices.