### PR TITLE
phase0a: introduce device refs and adb transports

### DIFF
--- a/openspec/changes/device-transport-refactor/SEAM-root-agent.md
+++ b/openspec/changes/device-transport-refactor/SEAM-root-agent.md
@@ -1,0 +1,146 @@
+# Seam: device-transport-refactor ↔ webscreen-root-agent
+
+本文档定义两个并行 OpenSpec change 之间的接缝。任何一侧改动若影响下列约束，必须同时更新另一侧并 cross-link PR。
+
+## 约束 1: root-agent transport 只挂 DeviceProvider + ScrcpyTransport
+
+`webscreen-root-agent` 提供的 transport 实现：
+
+```go
+// 由 webscreen-root-agent 在 Phase 2 完成后新增
+type rootAgentScrcpyTransport struct {
+    listener     net.Listener
+    sessions     *agentSessionRegistry   // 已在 sdriver/scrcpy/agent_transport.go
+    pairingToken []byte
+    // ...
+}
+
+var (
+    _ DeviceProvider  = (*rootAgentScrcpyTransport)(nil)
+    _ ScrcpyTransport = (*rootAgentScrcpyTransport)(nil)
+    // 故意不实现 ADBTransport
+)
+```
+
+`device-transport-refactor` 必须保证：
+
+- `ADBTransport` 接口签名不强行要求实现 `ScrcpyTransport` 之外的能力。
+- `BridgeRegistry.GetADB(bridgeID)` 对 `transport=root_agent` 的桥返回 `ErrTransportNotADB`，不 panic、不 fallback。
+- 任何调用方需要 ADB 能力时必须通过 `GetADB`，不能用 `interface{}` 类型断言强转 `rootAgentScrcpyTransport`。
+
+## 约束 2: ScrcpySession 是接缝唯一交付物
+
+`webscreen-root-agent` 当前已经在 `sdriver/scrcpy/agent_transport.go:163-172` 直接调用 `da.readDeviceMeta` / `da.assignConn`。重构后，agent transport 不再直接动 ScrcpyDriver 内部方法，而是把三条 raw stream 通过 `ScrcpySession` 返回：
+
+```go
+type ScrcpySession struct {
+    SCID              string
+    Video             net.Conn // raw bytes, scrcpy 原协议序列
+    Audio             net.Conn // opts.Audio=false 时为 nil
+    Control           net.Conn // opts.Control=false 时为 nil
+    NeedsForwardDummy bool     // root-agent transport 必须返回 true，详见约束 5.1
+    Close             func() error
+}
+```
+
+ScrcpyDriver 改造（属于 `device-transport-refactor` Phase 0b）：
+
+- 把 `connectRemoteADBSockets`（`driver.go:408`）和 `agent_transport.go:135-180` 的 stream 收集逻辑提取到 helper `gatherScrcpyConns(transport ScrcpyTransport) (*ScrcpySession, error)`。
+- helper 按 `session.NeedsForwardDummy` 决定是否先读 1 字节 dummy，再统一 `readDeviceMeta(firstConn) → assignConn(...)`。`readDeviceMeta` / `assignConn` 序列对所有 transport 保持不变（design.md 门禁：root-agent 不消费 dummy byte / device meta / codec header；helper 自己读 dummy 不算 agent 消费）。
+- ScrcpyDriver `New(...)` 接受 `ScrcpyTransport`，调用 `StartScrcpySession` 拿到 session，然后跑现有 `transferVideo / transferAudio / control` loop。
+
+## 约束 3: 虚拟 bridge 注册
+
+`webscreen-root-agent` agent 完成 hello + auth 后：
+
+```go
+registry.RegisterEphemeral(Bridge{
+    ID:           "agent-" + agentID,
+    Name:         deviceName + " (agent)",
+    Transport:    TransportRootAgent,
+    SecurityMode: SecurityShimHMAC,    // agent 已做 HMAC，不是 insecure
+    Enabled:      true,
+})
+```
+
+`device-transport-refactor` Phase 1a 必须保证：
+
+- `RegisterEphemeral` 不写盘。
+- ephemeral bridge 在前端 UI 显示 transport=root_agent，**禁用** delete / toggle 按钮（生命周期由 agent session 控制）。
+- agent session 断开时调用 `registry.Unregister(bridgeID)`。
+
+## 约束 4: 健康检查路径
+
+root-agent 桥的健康检查**不走** TCP / `adb -H -P devices -l`（adb host 协议在 agent 桥上不可用）。改走：
+
+- 检查 `agentSessionRegistry` 内 session 是否 active。
+- 上次 heartbeat 时间是否在窗口内（design.md:317-335 已定义 ping/pong）。
+
+`Bridge.Probe` 实现按 `Transport` 字段分派：
+
+```go
+switch b.Transport {
+case TransportLocalADB, TransportRemoteADB:
+    return b.probeADB(ctx, deep)
+case TransportRootAgent:
+    return b.probeAgent(ctx)
+}
+```
+
+`probeAgent` 仅查 in-memory session 状态，不开网络连接（agent 是主动连进来的）。
+
+## 约束 5: scid 来源
+
+`webscreen-root-agent` design.md:238 定义 config 由 Windows 下发 `scid`。`device-transport-refactor` Phase 0b 把 ScrcpyDriver 的 scid 改为 `GenerateSCID()` per-instance。两者通过 `ScrcpyOptions.SCID` 字段（design.md "ScrcpyTransport" 节定义）协同：
+
+- ScrcpyDriver 启动时 `GenerateSCID()`，存 `da.scid`。
+- 调用 `transport.StartScrcpySession(ctx, ref, ScrcpyOptions{SCID: da.scid, ...})`。
+- `ScrcpyOptions.SCID` 为空字符串时 transport 必须返回 `ErrSCIDRequired`，不允许 transport 内部默认填值。
+- `rootAgentScrcpyTransport` 把 `opts.SCID` 写入 control 协议的 config message 下发给 agent。
+- agent 启 scrcpy-server 时用该 scid。
+- 多并发 driver 各自 scid 唯一，agent 收到 stream_attach 时按 session_id（不是 scid）路由，session_id 也已经唯一。
+
+## 约束 5.1: NeedsForwardDummy=true（root-agent 必须）
+
+`device-transport-refactor` design.md "Dummy byte 状态对照表" 规定：root-agent transport 返回的 `ScrcpySession.NeedsForwardDummy` **必须为 `true`**。原因：
+
+- scrcpy-server 在 device 侧用 forward 隧道模式启动（`tunnel_forward=true`）。
+- agent 主动 dial PC 后，PC 收到的第一字节是 scrcpy 的 dummy byte（design.md:155-161 已规定 agent 不消费 dummy）。
+- `gatherScrcpyConns` helper 看 `session.NeedsForwardDummy=true` → 调用 `io.ReadFull(firstConn, dummy[:1])` → 然后 `readDeviceMeta(firstConn)`。
+
+实现侧：
+
+```go
+func (t *rootAgentScrcpyTransport) StartScrcpySession(ctx context.Context, ref DeviceRef, opts ScrcpyOptions) (*ScrcpySession, error) {
+    // ... 等待 session、下发 config、收集三条 stream attach
+    return &ScrcpySession{
+        SCID:              opts.SCID,
+        Video:             videoConn,
+        Audio:             audioConn,
+        Control:           controlConn,
+        NeedsForwardDummy: true,        // 强制 true
+        Close:             closeFn,
+    }, nil
+}
+```
+
+## 约束 6: Phase 时序
+
+| 时间 | device-transport-refactor | webscreen-root-agent |
+|---|---|---|
+| 现在 | Phase 0a 起 | Phase 2 进行中 (Windows transport 已部分落地) |
+| Phase 0a 完成后 | 接口定义稳定 | 可以开始把 `rootAgentScrcpyTransport` 改造成实现 `ScrcpyTransport` 接口 |
+| Phase 0b 完成后 | ScrcpyDriver 改造完成 | agent_transport.go 的 stream 收集逻辑迁移到 `StartScrcpySession` |
+| Phase 1a 完成后 | bridge registry 可用 | `RegisterEphemeral` 调用点接入 |
+| Phase 1b 完成后 | API 可用 | UI 显示 agent bridge |
+| Phase 1d 完成后 | UI 完整 | root-agent Phase 5 真机验收时一并验证多桥场景 |
+
+跨 change 的合并顺序：`device-transport-refactor` Phase 0a/0b 必须先于 `webscreen-root-agent` Phase 2 的 stream 收集重构。
+
+## 约束 7: 不重叠的范围
+
+- 协议 (control JSON / stream attach / heartbeat / file push) → 完全归 `webscreen-root-agent`。本变更不改协议、不改 fixture。
+- HMAC token 生命周期、replay window、SELinux → 完全归 `webscreen-root-agent`。
+- 接口定义、bridge 注册表、health probe、CheckOrigin、audit、并发清算 → 完全归 `device-transport-refactor`。本变更内不改 `agent_proto.go` / `agent_transport.go` 的协议逻辑。
+
+如果实现时发现需要跨界，必须先停下来在两个 change 各加一条 task 项，跨界改动作为新 PR 单独 review。

--- a/openspec/changes/device-transport-refactor/design.md
+++ b/openspec/changes/device-transport-refactor/design.md
@@ -1,0 +1,617 @@
+# Design: device-transport-refactor
+
+## 变更类型
+
+接口与并发清算 + 多桥注册表，跨多个 package，必须分 Phase 落地。
+
+设计范围允许覆盖：
+
+```text
+sdriver/
+sdriver/scrcpy/
+webservice/
+webservice/android/
+public/static/
+utils/
+openspec/changes/device-transport-refactor/
+```
+
+V1 不改：
+
+```text
+streamAgent/
+linuxRecorder/
+sdriver/linux/
+sdriver/sunshine/
+sdriver/dummy/
+sdriver/comm/
+public/screen.html (仅 device_id 读取处会变；HTML 结构不动)
+main.go (除新增 bootstrap 调用)
+```
+
+后续实现必须按 Phase 0a → 0b → 0c → 0d → 1a → 1b → 1c → 1d 顺序落 PR，每个 PR 单独 review。Phase 边界不得越级合并。
+
+## 设计门禁（来自用户）
+
+1. **RootAgentTransport 不实现 ADBTransport**。接口三分，root-agent 只能拿到 `DeviceProvider + ScrcpyTransport`。
+2. **socat 兼容期不靠 token**。`insecure_socat` 必须显式标记。安全责任在**桥机一侧**：桥机 socat `bind=Tailscale IP`、宿主防火墙、Tailscale ACL。webscreen 端只是显示警告，不能替代桥侧 ACL。真 HMAC 等 shim/agent。
+3. **健康检查不用 OpenLocalAbstract**。三段式：TCP / `adb -H -P devices -l` / 可选 per-device shell。
+4. **DeviceRef 必须版本化**。`v1.<base64url(json)>` 格式，decode 失败时按 legacy 本地 adb serial 迁移；display name 与 stable key 分离。
+
+任何阶段实现违反上述四点必须停下来重新提案，不得绕道。
+
+## 接口设计
+
+### DeviceProvider
+
+```go
+// sdriver/scrcpy/transport.go
+
+type DeviceDescriptor struct {
+    Ref       DeviceRef       // 主键
+    Display   string          // UI 显示名（model 或 user-rename）
+    Model     string          // 设备 model（来自 adb -l）
+    Status    DeviceStatus    // connected / unauthorized / offline / unknown
+    Transport TransportID     // 冗余字段方便前端分组；权威值在 Ref
+    Bridge    BridgeID        // 同上
+    LastSeen  time.Time
+}
+
+type DeviceStatus string
+
+const (
+    DeviceConnected    DeviceStatus = "connected"
+    DeviceUnauthorized DeviceStatus = "unauthorized"
+    DeviceOffline      DeviceStatus = "offline"
+    DeviceUnknown      DeviceStatus = "unknown"
+)
+
+type DeviceProvider interface {
+    Devices(ctx context.Context) ([]DeviceDescriptor, error)
+}
+```
+
+### ADBTransport
+
+```go
+type ADBTransport interface {
+    DeviceProvider
+
+    Shell(ctx context.Context, serial string, argv ...string) ([]byte, error)
+    Push(ctx context.Context, serial, src, dst string) error
+    Reverse(ctx context.Context, serial, remote, local string) error
+    ReverseRemove(ctx context.Context, serial, remote string) error
+    OpenLocalAbstract(ctx context.Context, serial, socketName string) (net.Conn, error)
+    Connect(ctx context.Context, addr string) error // 仅支持 tcpip 模式时
+    Pair(ctx context.Context, addr, code string) error
+
+    Capabilities() ADBTransportCaps
+    Bridge() BridgeID
+}
+
+type ADBTransportCaps struct {
+    CanReverse        bool // remote adb 上不可用
+    CanTCPIPConnect   bool // local adb / 某些远端可
+    CanPair           bool // Android 11+ 无线调试
+    SupportsDirectAbs bool // remote adb-server 可，local 需要 forward
+}
+```
+
+### ScrcpyTransport
+
+```go
+type ScrcpyTransport interface {
+    DeviceProvider
+
+    StartScrcpySession(ctx context.Context, ref DeviceRef, opts ScrcpyOptions) (*ScrcpySession, error)
+}
+
+type ScrcpySession struct {
+    SCID              string
+    Video             net.Conn // raw bytes, scrcpy 原协议序列
+    Audio             net.Conn // opts.Audio=false 时为 nil
+    Control           net.Conn // opts.Control=false 时为 nil
+    NeedsForwardDummy bool     // 见下表；true 时调用方必须先从首条非空 stream 读 1 字节 dummy
+    Close             func() error
+}
+
+type ScrcpyOptions struct {
+    SCID          string  // 由调用方注入；空时 transport 拒绝并报错（堵死历史 "00000000"）
+    Video         bool
+    Audio         bool
+    Control       bool
+    TunnelForward bool    // 决定隧道模式；transport 实现按下表强制
+    Codec         string  // "h264" | "h265" | ...
+    MaxSize       int
+    MaxFPS        int
+    BitrateKbps   int
+    // 其余与现有 ScrcpyDriver options map 一一对应
+}
+```
+
+#### Dummy byte 状态对照表
+
+scrcpy 的 forward dummy byte 仅在 **scrcpy-server 主动等待客户端连接** 的模式下出现 —— 这一字节由 scrcpy-server 在 accept 后立刻发出，用于通知 "real client attached"。reverse 模式（device 主动连出到 PC 的 listener）下 PC 侧只 accept，不会收到 dummy。
+
+| Transport / 模式 | 当前代码位置 | TunnelForward | NeedsForwardDummy |
+|---|---|---|---|
+| LocalADB reverse（device 连出） | `driver.go:352` | `false` | **false** |
+| LocalADB direct（PC 通过 `adb forward` 连入 localabstract） | 当前无此路径 | `true` | **true** |
+| RemoteADB direct（PC 通过 adb-server `localabstract:` 连入） | `driver.go:458-461` | `true` | **true** |
+| RootAgent（agent 主动 dial PC，scrcpy-server 在 device 侧 listen） | `agent_transport.go:159-163` | `true` | **true** |
+
+Phase 0b 提取 `gatherScrcpyConns` helper 时**必须**按 `session.NeedsForwardDummy` 字段决定是否调用 `io.ReadFull(firstConn, dummy[:1])`。错配会直接把 device meta 的第一个字节读掉，造成解析错位。
+
+`ScrcpyTransport` 的两个内置 adapter：
+
+- `adbScrcpyTransport{adb ADBTransport}`：用 `adb.Push` + `adb.Shell` 启动 scrcpy-server；按 `Capabilities().CanReverse` 决定走 reverse 或 direct-abs；返回的 `net.Conn` 来自 `adb.OpenLocalAbstract` 或本地 listener Accept。
+- `rootAgentScrcpyTransport`：由 `webscreen-root-agent` 提供，把 control JSON + 三条 raw stream attach 直接映射成 `ScrcpySession`。**不**实现 ADBTransport。
+
+`adbScrcpyTransport` 是包内 unexported helper，只接受 `ADBTransport` 入参。这样根本不会有"root-agent 包装成 adb"这种调用路径出现。
+
+### 为什么三分
+
+| 能力 | local adb | remote adb-server | root-agent |
+|---|---|---|---|
+| 列设备 | ✓ | ✓ | ✓（agent hello 时上报） |
+| 任意 shell | ✓ | ✓ | ✗（设计上拒绝） |
+| 任意 push | ✓ | ✓ | ✗（仅 allowlist 文件推送，受协议约束） |
+| pair / connect | ✓ | ✓（如果 server 跑得允许） | ✗ |
+| 启动 scrcpy + 拿三条 raw stream | ✓ | ✓ | ✓ |
+
+把后两者并到一个接口里，意味着调用方必须运行时 `if transport.HasCapability(...)`，错误路径会扩散；接口三分时调用方在编译期就拿不到非法能力。
+
+## DeviceRef v1
+
+### 字段
+
+```go
+type DeviceRef struct {
+    Transport TransportID // "local_adb" | "remote_adb" | "root_agent"
+    BridgeID  BridgeID    // "" for local_adb; "<id>" otherwise
+    Serial    string      // adb serial, 仅 *_adb transport 有意义
+    AgentID   string      // root_agent 专用
+}
+
+type TransportID string
+
+const (
+    TransportLocalADB  TransportID = "local_adb"
+    TransportRemoteADB TransportID = "remote_adb"
+    TransportRootAgent TransportID = "root_agent"
+)
+```
+
+### 编码
+
+```text
+v1.<base64url-no-pad(json-bytes)>
+```
+
+JSON 必须按字段名 ascii 排序：`{"agent_id":"","bridge_id":"...","serial":"...","transport":"..."}`。多余字段 reject。
+
+例：
+
+```text
+v1.eyJhZ2VudF9pZCI6IiIsImJyaWRnZV9pZCI6Im1hYy1jb3JhbCIsInNlcmlhbCI6IjVmOWU3OTQ3IiwidHJhbnNwb3J0IjoicmVtb3RlX2FkYiJ9
+```
+
+decode 算法：
+
+1. 输入若以 `v1.` 开头 → base64url-no-pad decode → JSON unmarshal → 字段校验。
+   - Transport 必须在 enum 内。
+   - `local_adb` 时 BridgeID 必须空且 AgentID 必须空。
+   - `remote_adb` 时 BridgeID 必须非空且 AgentID 必须空。
+   - `root_agent` 时 AgentID 必须非空（BridgeID 可为虚拟 `agent-<AgentID>`）。
+2. 输入不以 `v1.` 开头 → 视作 legacy 裸 adb serial → 返回 `DeviceRef{Transport: TransportLocalADB, Serial: input}` 并打 warn 日志。
+3. 编码格式不识别（如 `v2.`）→ 返回 `ErrUnknownDeviceRefVersion`，不静默 fallback。
+
+### 显示名与主键分离
+
+| 字段 | 是否参与等价 / 路由 | 是否可改 |
+|---|---|---|
+| DeviceRef | 是 | 否（改了等于换设备） |
+| Display | 否 | 是（用户 rename） |
+| Model | 否 | 仅来自 adb，不可手工改 |
+| Status | 否 | 探针写入 |
+
+WebRTC subscriber key、`/screen/:id` path 参数、前端 localStorage 全部用 `DeviceRef.Encode()`。
+
+### 老 `device_id` 迁移
+
+- 后端：`handleScreen.go:51` 的 `deviceIdentifier` 改成 `ref.Encode()`。如果接收到的字符串不以 `v1.` 开头，跑 legacy fallback 并 warn。
+- 前端：当前真实存储是单对象 `localStorage.webscreen_device_configs = { [serial]: {...} }` + 数组 `localStorage.webscreen_ignored_devices = [serial, ...]`（见 `public/static/console.js:6-7`）。迁移方式不动结构 key：
+  - 给 `webscreen_device_configs` 每个 entry 增加 `_ref: "v1.xxx"` 字段，老 serial key 保留 30 天。
+  - 并行新建 `webscreen_ignored_device_refs: ["v1.xxx", ...]`，老数组保留 30 天。
+  - 写 `webscreen_storage_schema_version = "2"` 标记已迁移；幂等。
+- 老链接（`/screen/5f9e7947`）：路由层判定不是 `v1.` 前缀时按 `local_adb` 解析，**返回 200 OK 正常进入 stream**。本变更不做 301 跳转 —— 老书签必须继续可用，301 留到 device_id 字段最终下线那次变更再加。
+
+## scrcpy driver 并发清算
+
+### 现状
+
+```go
+// sdriver/scrcpy/driver.go
+const (
+    SCRCPY_SERVER_LOCAL_PATH  = "./scrcpy-server"   // L26
+    SCRCPY_PROXY_PORT_DEFAULT = "27183"             // L28
+)
+
+func New(config map[string]string) (*ScrcpyDriver, error) {
+    da := &ScrcpyDriver{
+        scid: "00000000",                            // L86
+    }
+    ...
+    err = os.WriteFile(SCRCPY_SERVER_LOCAL_PATH, data, 0755)  // L100
+    localPort := SCRCPY_PROXY_PORT_DEFAULT                    // L106
+    ...
+}
+```
+
+`adbutils.go:27 GenerateSCID()` 已实现但无人调用。
+
+### 改造
+
+```go
+type ScrcpyDriver struct {
+    scid     string  // 8 byte 随机 hex
+    tmpDir   string  // os.MkdirTemp("", "scrcpy-srv-*")
+    proxyLn  net.Listener // reverse 模式才有，端口 = ln.Addr().Port
+    ...
+}
+
+func New(transport ScrcpyTransport, ref DeviceRef, config map[string]string) (*ScrcpyDriver, error) {
+    da := &ScrcpyDriver{
+        scid: GenerateSCID(),
+    }
+    var err error
+    da.tmpDir, err = os.MkdirTemp("", "scrcpy-srv-*")
+    if err != nil { return nil, err }
+
+    // ...写 scrcpy-server 到 da.tmpDir/scrcpy-server
+    // ...由 transport 决定 reverse vs direct
+
+    return da, nil
+}
+
+func (d *ScrcpyDriver) Close() error {
+    if d.proxyLn != nil { d.proxyLn.Close() }
+    if d.tmpDir != "" { os.RemoveAll(d.tmpDir) }
+    // ...
+}
+```
+
+reverse 模式动态端口：
+
+```go
+ln, err := net.Listen("tcp", "127.0.0.1:0")
+if err != nil { return nil, err }
+port := ln.Addr().(*net.TCPAddr).Port
+abs := fmt.Sprintf("localabstract:scrcpy_%s", d.scid)
+if err := adb.Reverse(ctx, ref.Serial, abs, fmt.Sprintf("tcp:%d", port)); err != nil { ... }
+d.proxyLn = ln
+```
+
+direct-abs 模式（remote adb 直接拿 conn）：
+
+```go
+videoConn, err := adb.OpenLocalAbstract(ctx, ref.Serial, fmt.Sprintf("scrcpy_%s", d.scid))
+// audio / control 同上
+```
+
+`ScrcpySession.Close` 必须：
+
+1. 关闭三条 raw stream
+2. （reverse 模式）`adb.ReverseRemove(..., abs)`
+3. 关闭 `proxyLn`
+4. `os.RemoveAll(tmpDir)`
+5. shell `pkill -f scrcpy-server.*scid=<scid>` —— 只 kill 自己的 scid，不要 `pkill app_process` 误杀别的 session
+
+## 多桥注册表
+
+### Bridge 数据模型
+
+```go
+type BridgeID string
+
+type Bridge struct {
+    ID           BridgeID      // 用户起名 / 自动生成（不可改）
+    Name         string        // UI 显示，可改
+    Transport    TransportID   // local_adb / remote_adb
+    Host         string        // remote_adb 必填
+    Port         int           // remote_adb 必填
+    SecurityMode SecurityMode  // insecure_socat / shim_hmac / none
+    TokenRef     string        // 指向 secret store 的 key，不存明文
+    Enabled      bool
+    Notes        string        // 用户备注
+    LastStatus   BridgeStatus  // 探针结果
+    LastSeen     time.Time
+}
+
+type SecurityMode string
+
+const (
+    SecurityNone          SecurityMode = "none"           // local adb
+    SecurityInsecureSocat SecurityMode = "insecure_socat" // 兼容期
+    SecurityShimHMAC      SecurityMode = "shim_hmac"      // 桥侧 shim 验签
+)
+
+type BridgeStatus struct {
+    TCPOk       bool
+    ADBOk       bool
+    DeviceCount int
+    LatencyMs   int
+    LastError   string  // 已 redact
+    CheckedAt   time.Time
+}
+```
+
+### 持久化
+
+`config/bridges.json`：
+
+```json
+{
+  "version": 1,
+  "bridges": [
+    {
+      "id": "local",
+      "name": "本机 ADB",
+      "transport": "local_adb",
+      "security_mode": "none",
+      "enabled": true
+    },
+    {
+      "id": "mac-coral",
+      "name": "Mac 桥 (NE2210)",
+      "transport": "remote_adb",
+      "host": "100.85.28.3",
+      "port": 15037,
+      "security_mode": "insecure_socat",
+      "enabled": true,
+      "notes": "socat 中转，无鉴权，依赖 Tailscale ACL"
+    }
+  ]
+}
+```
+
+文件权限：0600。token（如未来 shim_hmac 用）单独存入 OS secret store（Windows DPAPI / macOS Keychain / Linux libsecret），失败回退 0600 文件。
+
+### Bootstrap 兼容
+
+`main.go` 启动时：
+
+```go
+if v := os.Getenv("WEBSCREEN_REMOTE_ADB"); v == "1" {
+    host := envOr("WEBSCREEN_REMOTE_ADB_HOST", "ANDROID_ADB_SERVER_ADDRESS")
+    port := envOr("WEBSCREEN_REMOTE_ADB_PORT", "ANDROID_ADB_SERVER_PORT")
+    registry.RegisterEphemeral(Bridge{
+        ID:           "bootstrap-env",
+        Transport:    TransportRemoteADB,
+        Host:         host,
+        Port:         atoi(port),
+        SecurityMode: SecurityInsecureSocat,
+        Enabled:      true,
+    })
+    log.Println("[bridge] WEBSCREEN_REMOTE_ADB env detected, registered ephemeral bridge `bootstrap-env`. Persist via /api/bridge/add for permanent setup.")
+}
+```
+
+ephemeral bridge 不写盘，进程退出消失。这让 launcher / 现有脚本完全无感。
+
+### API
+
+| Method | Path | Body | 说明 |
+|---|---|---|---|
+| GET | `/api/bridge/list` | — | 返回所有 bridge + 最近 status |
+| POST | `/api/bridge/add` | `{name, transport, host?, port?, security_mode, token?, enabled}` | 持久化新桥；id 后端生成 |
+| POST | `/api/bridge/{id}/test` | `{deep: bool}` | 三段式健康检查，`deep=true` 跑 per-device shell echo |
+| POST | `/api/bridge/{id}/toggle` | `{enabled: bool}` | 启停 |
+| DELETE | `/api/bridge/{id}` | — | 删除桥；如果是 `bootstrap-env` 拒绝（用户应改环境变量） |
+
+所有 API 走现有 PIN 中间件。新增 `CheckOrigin` 白名单检查（管理 API 同样适用）。
+
+### 健康检查实现（按 transport 分派）
+
+不同 transport 的可探针面不一样，必须显式分派；不允许"默认 TCP probe"逻辑套到没有 host:port 的 transport 上。
+
+```go
+func (b *Bridge) Probe(ctx context.Context, deep bool) BridgeStatus {
+    s := BridgeStatus{CheckedAt: time.Now()}
+    switch b.Transport {
+    case TransportLocalADB:
+        return b.probeLocalADB(ctx, s)
+    case TransportRemoteADB:
+        return b.probeRemoteADB(ctx, s, deep)
+    case TransportRootAgent:
+        return b.probeRootAgent(ctx, s)
+    default:
+        s.LastError = "unknown transport"
+        return s
+    }
+}
+```
+
+#### probeLocalADB
+
+local_adb 没有 host:port，TCP 段跳过：
+
+```go
+func (b *Bridge) probeLocalADB(ctx context.Context, s BridgeStatus) BridgeStatus {
+    s.TCPOk = true // N/A，标记 true 避免 UI 误显示掉线
+    devices, err := b.Transport().Devices(ctx)
+    if err != nil {
+        s.LastError = redact(err.Error())
+        return s
+    }
+    s.ADBOk = true
+    s.DeviceCount = len(devices)
+    s.LatencyMs = int(time.Since(s.CheckedAt).Milliseconds())
+    return s
+}
+```
+
+#### probeRemoteADB（三段式）
+
+```go
+func (b *Bridge) probeRemoteADB(ctx context.Context, s BridgeStatus, deep bool) BridgeStatus {
+    // 1. TCP
+    dialCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+    defer cancel()
+    conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", net.JoinHostPort(b.Host, strconv.Itoa(b.Port)))
+    if err != nil {
+        s.LastError = redact(err.Error())
+        return s
+    }
+    conn.Close()
+    s.TCPOk = true
+
+    // 2. ADB host protocol via CLI: adb -H host -P port devices -l
+    devices, err := b.Transport().Devices(ctx)
+    if err != nil {
+        s.LastError = redact(err.Error())
+        return s
+    }
+    s.ADBOk = true
+    s.DeviceCount = len(devices)
+
+    // 3. Deep: per-device shell echo
+    if deep {
+        adb := b.Transport().(ADBTransport)
+        for _, d := range devices {
+            if d.Status != DeviceConnected { continue }
+            if _, err := adb.Shell(ctx, d.Ref.Serial, "echo", "alive"); err != nil {
+                s.LastError = fmt.Sprintf("device %s shell failed: %s", d.Ref.Serial, redact(err.Error()))
+                return s
+            }
+        }
+    }
+
+    s.LatencyMs = int(time.Since(s.CheckedAt).Milliseconds())
+    return s
+}
+```
+
+#### probeRootAgent（in-memory only）
+
+root-agent 是被动 listener：agent 主动连接 webscreen，session 状态保存在内存里的 `agentSessionRegistry`。健康检查不做出方向 dial，也不跑 adb：
+
+```go
+func (b *Bridge) probeRootAgent(ctx context.Context, s BridgeStatus) BridgeStatus {
+    sess, ok := agentSessions.GetByBridgeID(b.ID)
+    if !ok {
+        s.LastError = "agent session not active"
+        return s
+    }
+    if time.Since(sess.LastPong) > 30*time.Second {
+        s.LastError = "heartbeat stale"
+        return s
+    }
+    s.TCPOk = true
+    s.ADBOk = true // 语义上"transport 可用"，避免 UI 误判
+    s.DeviceCount = 1 // root-agent 一个 session 一台 device
+    s.LatencyMs = int(time.Since(sess.LastPong).Milliseconds())
+    return s
+}
+```
+
+`OpenLocalAbstract` **不出现在任何 Probe 路径**。
+
+## 横切安全
+
+### CheckOrigin 白名单
+
+```go
+// webservice/handleScreen.go
+var upgrader = websocket.Upgrader{
+    CheckOrigin: func(r *http.Request) bool {
+        return wm.config.IsAllowedOrigin(r.Header.Get("Origin"), r.Host)
+    },
+}
+```
+
+config：
+
+```yaml
+allowed_origins:
+  - same-host    # 默认：Origin host == Host header
+  - http://localhost:8081
+  - http://100.x.y.z:8081
+```
+
+### Audit 日志
+
+```go
+// sdriver/scrcpy/audit.go
+type AuditEntry struct {
+    Time     time.Time
+    BridgeID BridgeID
+    Serial   string
+    Action   string   // "shell" | "push" | "reverse" | "open_localabstract" | "connect" | "pair"
+    Summary  string   // redacted command summary, no full args
+    Duration time.Duration
+    Result   string   // "ok" | error class
+}
+```
+
+token / PIN / 文件内容 / shell stdout 不进 audit。
+
+### transport 调用 timeout
+
+每个 ADBTransport 方法外层 wrapper 强制 `context.WithTimeout`，默认 5s，可在 bridge config 覆盖。超时计入 BridgeStatus 的 `LastError` 并打 metric。
+
+### adb 可执行注入策略（明确二分）
+
+Phase 0a **不**重新实现 ADB sync protocol；CLI 类操作一律走标准 adb CLI 进程。但 `OpenLocalAbstract` 是 scrcpy 媒体流唯一接入点，必须走 raw socket（无法用 CLI 实现）。两边各管一边：
+
+| ADBTransport 方法 | 实现方式 |
+|---|---|
+| `Devices` / `Shell` / `Push` / `Connect` / `Pair` / `Reverse` / `ReverseRemove` | `exec(ADBExecutable, ...)` —— LocalADBTransport 不加 host/port 参数；RemoteADBTransport 加 `-H host -P port` |
+| `OpenLocalAbstract` | raw TCP → adb host protocol（`adbService("host:transport:serial")` + `adbService("localabstract:NAME")`）。沿用现有 `sdriver/scrcpy/remote_adb.go` 已经实现的路径 |
+
+两个 transport 构造时都必须显式注入 `ADBExecutable string` 字段；`utils.GetADBPath()` 自动下载副作用收敛在 `LocalADBTransport.New()` 一处：
+
+- `LocalADBTransport.New()` 调用 `utils.GetADBPath()` 取得路径，注入到 `ADBExecutable`。下载路径从 `cwd` 改为 `os.UserCacheDir()/webscreen/adb/`，文件名带版本，避免覆盖。
+- `RemoteADBTransport.New(host, port, adbExecutable)` 由 bridge registry 显式传入路径（默认沿用 `LocalADBTransport` 找到的那份）；**不**触发自动下载。
+- 测试时通过依赖注入传 fake `ADBExecutable`（用脚本桩或 fake adb-server 监听 raw socket）。`Devices/Shell/Push/Pair` 等测试用 mock exec 捕获 argv；`OpenLocalAbstract` 测试用 fake adb-server 监听 raw socket，按 adb host protocol 响应。两类测试互不重叠。
+
+## Phase 边界
+
+| Phase | 范围 | 不动 |
+|---|---|---|
+| 0a | 接口定义（transport.go）+ DeviceRef + adapter 骨架 + LocalADBTransport 实现 + RemoteADBTransport 实现 + 全部 adb 调用收口 | bridge registry / API / 前端 |
+| 0b | scrcpy driver 并发清算（scid / tmpDir / 动态端口） | bridge registry / API / 前端 |
+| 0c | CheckOrigin / audit log / timeout / GetADBPath 收敛 | bridge registry / API / 前端 |
+| 0d | 前端 device_id → DeviceRef 迁移；老链接兼容；localStorage upgrade | bridge registry / API |
+| 1a | bridge registry 持久化 + bootstrap 兼容层 | API / 前端 |
+| 1b | bridge API（list/add/test/toggle/delete） | 前端 |
+| 1c | 健康探针实现 + per-bridge timeout / circuit-breaker | 前端 |
+| 1d | 前端 bridge 管理 UI、设备分组、insecure 红标、deep test 按钮 | — |
+
+每 Phase 一个 PR，PR 之间不允许 squash。Phase 0 必须全部落完才能开 Phase 1。
+
+## 与 webscreen-root-agent 的接缝
+
+- 本变更只引入接口，不实现 RootAgentTransport。
+- `webscreen-root-agent` Phase 2 完成时，新增文件 `sdriver/scrcpy/root_agent_scrcpy_transport.go`，实现 `DeviceProvider + ScrcpyTransport`。
+- 该 transport 注册成虚拟 bridge：
+
+  ```go
+  Bridge{
+      ID:           "agent-" + agentID,
+      Name:         deviceName + " (agent)",
+      Transport:    TransportRootAgent,
+      SecurityMode: SecurityShimHMAC,
+      Enabled:      true,
+  }
+  ```
+
+- 注册时机：root-agent 完成 hello + auth 后，写入 in-memory 注册表；session 断开时删除（不持久化）。
+- 前端在桥列表里显示该桥的 `transport=root_agent`，没有 "test" 按钮（已经是 push 协议，无意义），有 "disconnect agent" 按钮。
+
+## 不在本变更范围的开放问题
+
+- 多用户 ACL、设备分组权限：未来变更。
+- 桥端 shim agent（替换 socat）：另立变更，复用 root-agent 的 control JSON + raw stream 协议。
+- Linux driver（`sdriver/linux`、`linuxRecorder`）的 transport 抽象：另立变更，本变更不动。
+- WebRTC 媒体下沉到桥：暂缓。

--- a/openspec/changes/device-transport-refactor/fixtures/device_ref/local_5f9e7947.json
+++ b/openspec/changes/device-transport-refactor/fixtures/device_ref/local_5f9e7947.json
@@ -1,0 +1,1 @@
+{"agent_id":"","bridge_id":"","serial":"5f9e7947","transport":"local_adb"}

--- a/openspec/changes/device-transport-refactor/fixtures/device_ref/remote_mac_coral_5f9e7947.json
+++ b/openspec/changes/device-transport-refactor/fixtures/device_ref/remote_mac_coral_5f9e7947.json
@@ -1,0 +1,1 @@
+{"agent_id":"","bridge_id":"mac-coral","serial":"5f9e7947","transport":"remote_adb"}

--- a/openspec/changes/device-transport-refactor/fixtures/device_ref/root_agent_coral.json
+++ b/openspec/changes/device-transport-refactor/fixtures/device_ref/root_agent_coral.json
@@ -1,0 +1,1 @@
+{"agent_id":"coral","bridge_id":"agent-coral","serial":"","transport":"root_agent"}

--- a/openspec/changes/device-transport-refactor/proposal.md
+++ b/openspec/changes/device-transport-refactor/proposal.md
@@ -1,0 +1,118 @@
+# Change: device-transport-refactor
+
+## 状态
+
+draft
+
+## 用户确认的方向
+
+- 目标是让 webscreen 在不破坏现有 USB / 远程 ADB 桥 / `webscreen-root-agent` 路径前提下，支持同时管理多台桥、多台设备。
+- 改造拆为 Phase 0（接口抽象 + 并发清算 + 横切安全）和 Phase 1（多桥注册表）。Phase 2 完全沿用 `webscreen-root-agent` OpenSpec，不在本变更内引入新协议。
+- root-agent transport **不实现 ADBTransport**。它没有任意 shell / 任意 push / pair / connect，把它塞进 ADBTransport 会破坏安全边界。三分接口为：`DeviceProvider`、`ADBTransport`、`ScrcpyTransport`。
+- Phase 1 的 bridge token **不保护裸 socat**。socat 兼容期必须显式标记 `insecure`。安全责任在**桥机一侧**：桥机 socat `bind=Tailscale IP` + 桥机宿主防火墙 + Tailscale ACL。webscreen 自己的 HTTP listener bind 和桥安全无关，不能用 webscreen 端 bind 来"保护" socat。真正 HMAC 必须等桥侧 shim/agent 验证后才成立。
+- bridge 健康检查不用 `OpenLocalAbstract` —— scrcpy-server 未启动时它无意义。健康探针必须包含 TCP connect、`adb -H -P devices -l`（ADB host 协议），并支持可选 per-device `shell echo alive`。
+- `DeviceRef` 必须**版本化**编码：格式 `v1.<base64url(json)>`，decode 失败时按 legacy 本地 adb serial 迁移。display name / model / status 和 stable key 必须分开，避免 UI 名称变化影响配置绑定。
+- 旧 `WEBSCREEN_REMOTE_ADB_*` 环境变量保留为 bootstrap 语法糖（启动时自动注册一条 bridge），不再作为运行时单点。
+- 本变更不动 WebRTC、不动编码器选择、不重写 streamAgent 主链路、不下沉媒体到桥。
+
+## 背景
+
+当前 ADB 调用面散落在 12 处，跨 4 个文件，且存在 2 种调用风格（一种走 `utils.GetADBPath()`，一种硬编码字符串 `"adb"`）：
+
+| 文件 | 行 | 调用 | 用途 |
+|---|---|---|---|
+| `webservice/android/connect.go` | 11 | `ExecADB(args)` | 通用 adb 入口（无 ctx） |
+| `webservice/android/connect.go` | 23 | `GetDevices` → `adb devices` | 设备列表 |
+| `webservice/android/connect.go` | 65 | `ConnectDevice` → `adb connect ADDR` | tcpip 连接 |
+| `webservice/android/connect.go` | 82 | `PairDevice` → `adb pair ADDR CODE` | 无线调试配对 |
+| `sdriver/scrcpy/adbutils.go` | 15 | `ExecADB(ctx, args)` | scrcpy 内部 adb（带 ctx）— 与上面重复定义 |
+| `sdriver/scrcpy/adbutils.go` | 75 | `GetConnectedDevices` → `adb devices` | scrcpy 设备探测 |
+| `sdriver/scrcpy/adbutils.go` | 101 | `ConnectDevice` | 与 `webservice/android` 重复 |
+| `sdriver/scrcpy/adbutils.go` | 118 | `PairDevice` | 与 `webservice/android` 重复 |
+| `sdriver/scrcpy/adb.go` | 122 | `exec.CommandContext(ctx, "adb", ...)` | encoder 探测，**硬编码字符串，绕过 GetADBPath** |
+| `sdriver/scrcpy/adb.go` | 159 | `exec.CommandContext(ctx, "adb", ...)` | opus 探测，**同上** |
+
+结果：
+
+1. webscreen 进程级只能绑定一台桥（`remote_adb.go:14-36` 读取 `WEBSCREEN_REMOTE_ADB_*` 单例 env）。
+2. encoder 探测的 `"adb"` 硬编码绕过 `GetADBPath`，远程 adb 切桥时**列表来自桥机、encoder 探测打到本地 adb**，路由错位（你指出的第 2 点）。
+3. scrcpy driver 三处写死共享资源：
+   - `driver.go:26` `SCRCPY_SERVER_LOCAL_PATH = "./scrcpy-server"` —— 多 session 并发时 `os.WriteFile`（`driver.go:100`）和 `os.Remove`（`driver.go:132`）会互相覆盖/删除。
+   - `driver.go:28` `SCRCPY_PROXY_PORT_DEFAULT = "27183"` —— 多 session reverse 模式抢同一 TCP 端口。
+   - `driver.go:86` `scid: "00000000"` —— 抽象 socket 名 `scrcpy_00000000` 多 session 撞名。`adbutils.go:27 GenerateSCID()` 已经实现但**无人调用**（dead code）。
+4. `utils.GetADBPath()`（`utils/adb.go:18-44`）找不到 adb 时会下载到 `cwd`，是进程级副作用，进一步把 webscreen 跟单一 adb 绑定。
+5. WebSocket 接受任意 Origin（`webservice/handleScreen.go:15-19` `CheckOrigin: return true`）。
+6. WebRTC subscriber key 是字符串拼接 `DeviceType_DeviceID_DeviceIP_DevicePort`（`handleScreen.go:51`），同时 14 处前后端代码依赖 `device_id` 字段作为主键。
+7. 当前没有桥健康检查；远程 adb-server 在 Tailnet 上裸暴露完整 shell 权限。
+
+## 目标
+
+### Phase 0 — 抽象与清算（无新功能）
+
+- **接口三分**：在 `sdriver/scrcpy/transport.go` 新增三个接口，互不继承：
+  - `DeviceProvider`：`Devices(ctx) ([]DeviceDescriptor, error)`。所有列表来源（local adb / remote adb / root-agent / future）都实现这个。
+  - `ADBTransport`：扩展 `DeviceProvider`，提供 `Shell` / `Push` / `Reverse` / `ReverseRemove` / `OpenLocalAbstract` / `Connect` / `Pair`。**只有** local/remote adb 实现。
+  - `ScrcpyTransport`：`StartScrcpySession(ctx, opts) (*ScrcpySession, error)`，返回的 session 内含 `Video / Audio / Control net.Conn`。Local/remote adb 通过共享 helper 把 `ADBTransport` 包成 `ScrcpyTransport`；root-agent 直接实现 `ScrcpyTransport`。
+- **DeviceRef v1**：所有跨层主键改成 `DeviceRef{Transport, BridgeID, Serial, AgentID}`，对外编码 `v1.<base64url(json)>`。Display name / model / status 单独字段。Legacy `device_id`（裸 adb serial）在 decode 失败时按 `v1` 补齐 `{Transport:"local_adb", Serial:legacy}` 迁移，前端启动时一次性 upgrade localStorage。
+- **scrcpy driver 并发安全**：
+  - `scid` 改为 `GenerateSCID()` 输出，每个 driver 实例独立。
+  - scrcpy-server 落盘改为 `os.MkdirTemp("", "scrcpy-srv-*")` per-driver，`Close()` 清理。
+  - reverse 模式（仅 local adb 走）通过 `net.Listen("tcp", "127.0.0.1:0")` 拿动态端口；remote-adb / root-agent 强制 direct-socket。
+- **adb 调用收口**：删除 `sdriver/scrcpy/adb.go:122/159` 的硬编码 `"adb"`；删除 `sdriver/scrcpy/adbutils.go` 中与 `webservice/android` 重复的 `ConnectDevice/PairDevice/GetConnectedDevices`，统一走 transport。
+- **横切安全**：
+  - `handleScreen.go:15` `CheckOrigin` 从 `return true` 改为读取配置白名单，默认拒绝跨 origin。
+  - transport 每次调用强制 per-call timeout，默认 5s，超时计入 bridge 状态。
+  - 每次 adb 调用写一行 audit 日志：`time, bridge_id, serial, cmd_summary, duration, result`。token / pin 等敏感数据不进日志。
+
+### Phase 1 — 多桥注册表
+
+- `config/bridges.json` 持久化：`[{id, name, transport, host, port, security_mode, token?, enabled, last_status}]`。
+- `security_mode` 取值：
+  - `insecure_socat` —— 兼容旧桥；webscreen 启动时打印警告，UI 标红。
+  - `shim_hmac` —— 桥侧跑我们的 shim 校验 HMAC（Phase 1 之后）。
+  - `none` —— local adb，不适用 token。
+- 新增 API：`GET /api/bridge/list`、`POST /api/bridge/add`、`POST /api/bridge/{id}/test`、`DELETE /api/bridge/{id}`。
+- 桥健康检查（必须三段式）：
+  1. TCP connect to `host:port`，3s 超时。
+  2. `adb -H host -P port devices -l`，解析输出。
+  3. 可选 per-device `adb -H host -P port -s SERIAL shell echo alive`，仅 UI 主动点 "deep test" 时执行。
+- `GET /api/device/list` 并发遍历所有 enabled bridge（fan-out + per-bridge 3s 超时），返回 `DeviceRef.Encode()` 列表。
+- 前端：桥管理页面、设备按桥分组、insecure 桥红标、deep test 按钮。
+
+## 非目标
+
+- **不实现 root-agent transport**。该 transport 在 `webscreen-root-agent` Phase 2/4 完成后，注册成虚拟 bridge（`bridge_id=agent-<agent_id>`，`security_mode=shim_hmac`），仅挂 `DeviceProvider + ScrcpyTransport`，不挂 `ADBTransport`。本变更只确保接口拆分能容纳它。
+- 不实现 Phase 3 桥侧 agent；socat 兼容期靠 Tailscale ACL，不引入新协议。
+- 不下沉 WebRTC 到桥/agent；本变更不动 `webRTCManager.go` 主链路（仅替换 subscriber key 类型）。
+- 不动 `streamAgent`、`linuxRecorder`、编码器选择。
+- 不重写 `scrcpy-server`。
+- 不引入多租户、多用户 ACL；PIN 仍为全局单一鉴权。
+- 不做 Linux driver 的 transport 抽象（独立改造，不在本变更范围）。
+
+## 安全边界
+
+- WebSocket `CheckOrigin` 默认 same-origin；额外允许列表必须显式配置。
+- `insecure_socat` bridge 的**安全责任在桥机一侧，不在 webscreen**。webscreen 只对桥做出方向 dial，不为桥监听任何端口；webscreen 的 HTTP listener bind（`-host 0.0.0.0` vs Tailscale IP）和桥安全完全无关。真正要限制的对象：
+  - 桥机 socat 必须 `bind=100.x.y.z`（Tailscale 接口 IP），禁止 `bind=0.0.0.0`。
+  - 桥机宿主防火墙仅允许 Tailscale 网卡入站到 socat 端口。
+  - Tailscale ACL 限制只有 webscreen 主机的 tailnet identity 能访问该端口。
+  - webscreen 在桥被标 `insecure_socat` 时强提示 UI 红标 + 启动日志 warning，但提示文案必须说 "webscreen 端无法替代桥侧 ACL"。
+- bridge token 仅在 `shim_hmac` 模式下传输；明文 token 不进 audit 日志、不进 process listing、不进 `config/bridges.json` 明文存储（用 `crypto/rand` 生成 + DPAPI/keychain/file-mode 0600 选其一）。
+- transport 调用 audit 日志默认开启，落 `webscreen-audit.log`；条目格式固定、不含敏感字段。
+- DeviceRef 编码层不接受不在 enum 内的 `Transport`；decode 失败回退为 legacy 时打 warn 日志，不静默通过。
+- scrcpy-server 临时目录 `os.MkdirTemp` 默认 0700；`Close()` 必须删除临时目录。
+- `utils.GetADBPath()` 自动下载行为在本变更内**收敛**：仅 `LocalADBTransport` 显式调用，且写入路径改为 `os.UserCacheDir()/webscreen/adb/`，不再写 cwd。
+
+## 验收
+
+- `grep -rn "exec.Command.*adb\"" sdriver/ webservice/ utils/` 在业务代码内为空（utils 内允许 `LocalADBTransport` 私有实现）。
+- 单 webscreen 进程同时跑两条 scrcpy session（同桥不同设备 / 不同桥），无文件 / 端口 / scid 冲突，关闭后无残留临时目录。
+- `WEBSCREEN_REMOTE_ADB_*` 拆为 bootstrap 语法糖，仅在启动时调用 `bridge_registry.Register(...)`；运行时无任何代码再读这 5 个 env。
+- 两台 bridge 同时注册（一台 mac socat，一台 windows local adb），`GET /api/device/list` 返回两台设备并各自标 bridge_id。
+- `POST /api/bridge/{id}/test` 对一个 unauthorized 设备返回 `device_count=1, devices=[{serial, status:"unauthorized"}]`，对一个 fail bridge 返回 `tcp_ok=false`，对一个空桥返回 `tcp_ok=true, adb_ok=true, device_count=0`。
+- 前端旧 `device_id` localStorage 在首次启动后被 upgrade 成 `DeviceRef v1`，且老页面书签链接（含旧 device_id 参数）仍可解析。
+- DeviceRef decode 失败的请求返回 `400 invalid_device_ref`，不会静默落到默认设备。
+- WebSocket 跨 origin 请求被拒绝并返回 `403 origin_not_allowed`。
+- audit 日志包含 bridge_id 切换、health probe、连接事件；不含 token / PIN。
+- 全部 Phase 1 OpenSpec fixture（见 `fixtures/`）有对应 Go 单元测试通过。
+- 旧 ADB 路径（USB 直连 / 现有单桥 socat）regression 通过。

--- a/openspec/changes/device-transport-refactor/tasks.md
+++ b/openspec/changes/device-transport-refactor/tasks.md
@@ -1,0 +1,191 @@
+# Tasks: device-transport-refactor
+
+## 0. 审核门禁
+
+- [x] 用户拍板 Phase 顺序：Phase 0a → 0b → 0c → 0d → 1a → 1b → 1c → 1d，跨 Phase 不合并 PR。
+- [x] 用户确认 RootAgentTransport 不实现 ADBTransport，接口三分。
+- [x] 用户确认 socat 兼容期标 `insecure_socat`，安全责任在桥机一侧：桥机 socat `bind=Tailscale IP` + 桥机宿主防火墙 + Tailscale ACL。webscreen 端只显示警告，无法替代桥侧 ACL，不靠 token。
+- [x] 用户确认健康检查不用 `OpenLocalAbstract`，三段式：TCP / `adb -H -P devices -l` / 可选 per-device shell。
+- [x] 用户确认 DeviceRef 编码为 `v1.<base64url(json)>`，legacy 裸 serial 按 local_adb 迁移并 warn。
+- [x] 用户确认 `WEBSCREEN_REMOTE_ADB_*` 降级为 bootstrap ephemeral bridge，不持久化。
+- [x] 用户确认本变更不动 streamAgent / linuxRecorder / sdriver/linux / WebRTC 主链路。
+- [x] 用户确认本变更不实现 root-agent transport，只确保接口能容纳；具体实现走 `webscreen-root-agent` 变更。
+- [x] 用户确认 Go toolchain 政策：本地装 1.25.4 或开启 `GOTOOLCHAIN=auto` 自动下载（go.mod 第 3 行已确认 `go 1.25.4`，无 toolchain 行）。**不**为本机 1.23.6 降项目版本。
+- [x] 用户确认 token 存储策略：Windows DPAPI 优先，回退 0600 文件（macOS Keychain / Linux libsecret 留待 Phase 1c 补）。
+- [x] 用户确认前端 localStorage 老 key 保留窗口：默认 30 天后清理；迁移目标按 `webscreen_device_configs` / `webscreen_ignored_devices` 真实结构走。
+
+## 1. Baseline
+
+- [x] 列出全部 12 处 ADB 调用点和 2 种调用风格（写入 proposal 背景表）。
+- [x] 列出 scrcpy driver 三处并发不安全位点（写入 design）。
+- [x] 列出 14 个引用 `device_id` 的文件（grep 结果归档）。
+- [ ] 记录现有 launcher（`launcher/`）启动 webscreen 时设置的全部 env，确认 bootstrap 兼容层覆盖完整。
+- [ ] 记录现有 frontend localStorage key 名空间（grep `webscreen.` 前缀），确认迁移脚本范围。
+
+## 2. Phase 0a: 接口拆分 + adb 调用收口
+
+PR 边界：纯重构，不改运行时行为。
+
+- [x] 新增 `sdriver/scrcpy/transport.go`：`DeviceProvider` / `ADBTransport` / `ScrcpyTransport` / `ADBTransportCaps`。
+- [x] 新增 `sdriver/device_ref.go`：`DeviceRef`, `Encode/Decode`, legacy 迁移 helper, 单元测试覆盖 `fixtures/device_ref/*.json`。
+- [x] 新增 `sdriver/scrcpy/local_adb_transport.go`：实现 `ADBTransport`，封装现有 `utils.GetADBPath()` + `exec`。
+- [x] 新增 `sdriver/scrcpy/remote_adb_transport.go`：替换 `remote_adb.go` 现有全局 env 读取，构造函数显式接受 `host, port`，实现 `ADBTransport`（`OpenLocalAbstract` 复用现有 `adbService` 逻辑）。
+- [x] 新增 `sdriver/scrcpy/adb_scrcpy_transport.go`：内部 adapter，`adbScrcpyTransport{adb ADBTransport}` 实现 `ScrcpyTransport`。
+- [x] 替换 `webservice/android/connect.go:11/23/65/82`：所有调用走 `ADBTransport`。
+- [x] 替换 `sdriver/scrcpy/adb.go:122/159`：硬编码 `"adb"` 改走 `transport.Shell(...)`。
+- [x] 删除 `sdriver/scrcpy/adbutils.go` 中与 `webservice/android` 重复的 `ConnectDevice/PairDevice/GetConnectedDevices`，保留通用 helper（`scrcpyParamsToArgs`, `toScrcpyCommand`）。
+- [x] 删除 `webservice/android/connect.go:11 ExecADB` 重复定义，保留单一定义在 transport 实现内。
+- [x] `LocalADBTransport.New()`：调用 `utils.GetADBPath()` 取得路径并注入到 `ADBExecutable` 字段；CLI 操作走 `exec(ADBExecutable, ...)`。
+- [x] `RemoteADBTransport.New(host, port, adbExecutable)`：构造时显式接受 `adbExecutable`；不调用 `GetADBPath`；CLI 操作走 `exec(ADBExecutable, "-H", host, "-P", port, ...)`；`OpenLocalAbstract` 走 raw socket（复用现有 `remote_adb.go` 的 `adbService` 路径）。
+- [x] 单元测试：
+  - [x] `transport_contract_test.go`：用 fake transport 验证 `ADBTransport` 全部方法签名能编译。
+  - [x] `device_ref_test.go`：编码 / 解码 / legacy fallback / 未知版本拒绝 / 字段约束。
+  - [x] `local_adb_transport_test.go`：mock `exec.Command`，验证 `-s SERIAL` 路由。
+  - [x] `remote_adb_transport_test.go`：local fake adb-server，验证 `host:transport:` + `devices` / `OpenLocalAbstract`。
+- [ ] 回归：`go test ./...` 通过；旧 launcher 启动 webscreen 后 `/api/device/list` 行为不变。
+
+## 3. Phase 0b: scrcpy driver 并发清算
+
+PR 边界：动 `sdriver/scrcpy/driver.go` 内 New/Close 及临时文件管理；不改协议、不改 transport 接口。
+
+- [ ] `ScrcpyDriver` 新增 `tmpDir`, `proxyLn` 字段。
+- [ ] `New(...)`：
+  - [ ] `scid = GenerateSCID()` 替换 `sdriver/scrcpy/driver.go:86` 的 `"00000000"`（scid 改动**只在本 Phase 出现**，0a 不动）。
+  - [ ] `ScrcpyOptions.SCID` 必填（空字符串时 transport 拒绝并报 `ErrSCIDRequired`），由 ScrcpyDriver 构造 session 前注入。
+  - [ ] `os.MkdirTemp("", "scrcpy-srv-*")` 替换 `SCRCPY_SERVER_LOCAL_PATH`。
+  - [ ] reverse 模式 `net.Listen("127.0.0.1:0")` 拿动态端口；direct 模式直接调 `OpenLocalAbstract`。
+  - [ ] 提取 `gatherScrcpyConns(transport ScrcpyTransport, opts ScrcpyOptions) (*ScrcpySession, error)` helper：
+    - reverse 路径（LocalADB tunnel_forward=false）：accept 三条 conn，**不读 dummy**，直接 `readDeviceMeta(firstConn)`，对应 `session.NeedsForwardDummy=false`。
+    - direct 路径（RemoteADB / LocalADB forward）：拿到三条 raw conn 后 `io.ReadFull(firstConn, dummy[:1])` 再 `readDeviceMeta(firstConn)`，对应 `session.NeedsForwardDummy=true`。
+    - 把 `driver.go:331 connectRemoteADBSockets` 和 `driver.go:344-384` 的 reverse Accept 块合并到这个 helper，去掉两条重复路径。
+    - root-agent 已在 `agent_transport.go:135-180` 完成 stream 收集；按 SEAM 约束 2 在 webscreen-root-agent 侧迁移到 `StartScrcpySession` 返回 `ScrcpySession{NeedsForwardDummy: true}`。
+- [ ] `Close()`：删 tmpDir、关 proxyLn、`ReverseRemove`、按 `scid` 精确 kill 远端 scrcpy-server 进程。
+- [ ] 删除常量 `SCRCPY_SERVER_LOCAL_PATH` / `SCRCPY_PROXY_PORT_DEFAULT`（grep 确认无外部引用）。
+- [ ] 修改 `driver.go:127/132` 改成 tmpDir 路径。
+- [ ] 单元测试：
+  - [ ] `driver_concurrent_test.go`：并发起 4 个 driver 实例，验证 scid / tmpDir / 端口互不冲突。
+  - [ ] `driver_cleanup_test.go`：`Close()` 后 tmpDir 被删除，proxyLn 关闭。
+- [ ] 集成测试（手动）：用单 webscreen 进程对同一桥的两个设备各起 session，观察两条 scrcpy 视频流并行。
+- [ ] 回归：单设备路径行为不变；旧 reverse 模式仍可用。
+
+## 4. Phase 0c: 横切安全（CheckOrigin / audit / timeout / GetADBPath）
+
+- [ ] `webservice/handleScreen.go:15`：`CheckOrigin` 改为读 `wm.config.AllowedOrigins`，默认 `same-host`。
+- [ ] `WebMaster` 添加 `SetAllowedOrigins([]string)` 方法；启动 flag `-allow-origin` 支持多次。
+- [ ] 新增 `sdriver/scrcpy/audit.go`：`AuditEntry` + 全局 logger。
+- [ ] 所有 `ADBTransport` 方法在 transport 实现层包装 audit 写入。
+- [ ] 所有 `ADBTransport` 方法在调用层强制 `context.WithTimeout(5s)`，可被外层 ctx 覆盖。
+- [ ] `utils/adb.go:GetADBPath`：
+  - [ ] 下载路径从 `cwd` 改为 `os.UserCacheDir()/webscreen/adb/`。
+  - [ ] 文件名包含版本号。
+  - [ ] 仅 `LocalADBTransport` 调用；`RemoteADBTransport` 移除依赖。
+- [ ] 单元测试：
+  - [ ] `check_origin_test.go`：same-host 通过；跨 origin 拒绝；显式 allowlist。
+  - [ ] `audit_test.go`：token / PIN / shell 内容不进 audit。
+  - [ ] `transport_timeout_test.go`：transport 5s 超时返回明确 error。
+- [ ] 文档：更新 `launcher/` README 提到新增 flag。
+
+## 5. Phase 0d: 前端字段加 device_ref（device_id 保 legacy 兼容期）
+
+**重要**：当前前端的 `device_id` 是设备名 / 配置 key / 显示，不能直接替换成 ref encoded（ref 太长，且 console.js 大量按 serial 索引 `webscreen_device_configs`）。本 Phase 走"新增字段"路线，旧字段保留 legacy 语义到迁移期结束。
+
+- [ ] `webservice/apiDevices.go DeviceInfo` 新增字段：
+  - `device_ref` (string): `DeviceRef.Encode()` 的 v1 编码，新前端用。
+  - `bridge_id` (string): bridge 显示用。
+  - `display` (string): UI 显示名（默认 model，可被前端 rename 覆盖）。
+  - `model` (string): adb 返回的 model 字段。
+  - 保留 `device_id` (string): **legacy 裸 serial**，未来 phase 才退场；本 phase 不动其语义，避免老前端炸。
+- [ ] `webservice/handleScreen.go:51`：`deviceIdentifier` 改为优先用 `config.DeviceRef`（若为空 fallback `DeviceID`），底层走 `DecodeDeviceRef` 容错。
+- [ ] `webservice/webRTCManager.go`：subscriber map 的 key 改用 `DeviceRef.Encode()`；调用方传 ref encoded。`DeviceID` 老值兼容期通过 legacy decode 升格成 `DeviceRef{Transport: local_adb, Serial: <legacy>}`。
+- [ ] 后端路由 `/screen/:id`：判断不是 `v1.` 时跑 legacy fallback（按 local_adb 解析）；不强制 301，老链接继续可用（待 Phase 1 之后再加 301）。
+- [ ] 前端 `public/static/console.js`：
+  - [ ] 在 `loadIgnoredDevices` / `STORAGE_KEY = 'webscreen_device_configs'`（`console.js:6-7`）基础上新增迁移函数 `migrateDeviceConfigs()`：
+    - `webscreen_device_configs` 当前结构为 `{ [serial]: { ...config } }`。迁移目标：每个 entry 新增 `_ref` 字段（值为对应 DeviceRef encoded）；老 serial key 保留 30 天。
+    - `webscreen_ignored_devices` 当前结构为 `string[]`（serial 数组）。迁移目标：新增并行数组 `webscreen_ignored_device_refs`（v1 encoded），旧数组保留 30 天。
+    - 写入 metadata `webscreen_storage_schema_version = 2`，已迁移过则跳过。
+    - 迁移函数必须**幂等**：多次调用结果相同。
+- [ ] 前端 `public/static/connect.js` / `screen.js`：
+  - [ ] 设备列表渲染时读 `device.device_ref || device.device_id`。
+  - [ ] 启动 stream 的链接生成优先用 `device_ref`，无 ref 时 fallback `device_id`。
+- [ ] 单元测试：
+  - [ ] `device_ref_migration_test.go`（Go）：legacy bare serial → `v1.{Transport:local_adb, Serial:<legacy>}`，多次解码幂等。
+  - [ ] `console_storage_migration_test.js`（jsdom）：注入 `webscreen_device_configs = {"5f9e7947": {pin: 1234}}`，跑 migrate → entry 新增 `_ref`，老 key 不丢；二次跑无副作用。
+  - [ ] `handle_screen_legacy_test.go`：GET `/screen/5f9e7947` 不报错，subscriber key = local_adb encode 结果。
+- [ ] 手动验证：清 localStorage 后访问老书签 `http://localhost:8081/screen/5f9e7947` → 正常进入 stream，且 console 设备列表里同时显示 `device_id=5f9e7947` 和 `device_ref=v1.xxx`。
+
+## 6. Phase 1a: bridge registry 持久化 + bootstrap 兼容
+
+- [ ] 新增 `webservice/bridge_registry.go`：内存 + 文件持久化（`config/bridges.json`）。
+- [ ] 新增 `webservice/bridge_secret.go`：token 存储抽象（Windows DPAPI 实现 + 文件回退）。
+- [ ] `main.go` 启动顺序：
+  1. 加载 `config/bridges.json`（不存在则创建空）。
+  2. 如检测到 `WEBSCREEN_REMOTE_ADB=1`，注册 `bootstrap-env` ephemeral bridge。
+  3. 初始化 webMaster。
+- [ ] `bridges.json` 文件权限 0600；启动时校验，不符合则 refuse to start 并提示修权。
+- [ ] 单元测试：
+  - [ ] `registry_persist_test.go`：写入 / 读取 / 版本号检测。
+  - [ ] `bootstrap_env_test.go`：env 存在时注册 ephemeral，不写盘；env 不存在时无副作用。
+- [ ] 回归：现有 launcher 设置 5 个 env 启动 webscreen，行为完全不变。
+
+## 7. Phase 1b: bridge API
+
+- [ ] 新增 `webservice/handleBridges.go`：
+  - [ ] `GET /api/bridge/list`
+  - [ ] `POST /api/bridge/add`
+  - [ ] `POST /api/bridge/:id/test`
+  - [ ] `POST /api/bridge/:id/toggle`
+  - [ ] `DELETE /api/bridge/:id`
+- [ ] 所有路由挂在现有 PIN 中间件下。
+- [ ] `bootstrap-env` 桥拒绝 DELETE，提示用户改 env 变量。
+- [ ] `GET /api/device/list` 改造：并发遍历所有 enabled bridge，3s 单桥超时，按 bridge_id 分组返回，每个设备项带 `device_ref`。
+- [ ] 单元测试：
+  - [ ] `handle_bridges_test.go`：CRUD 全路径。
+  - [ ] `device_list_fanout_test.go`：3 个桥并发；其中 1 个故障不阻塞另外 2 个。
+- [ ] 回归：单桥场景行为同 0a 末态。
+
+## 8. Phase 1c: 健康探针
+
+- [ ] 新增 `webservice/bridge_probe.go`：实现三段式 probe（TCP / Devices / 可选 shell echo）。
+- [ ] `BridgeStatus` 写入注册表，UI 可查。
+- [ ] 启动后台 goroutine：每 30s 对 enabled bridge 跑非 deep probe；失败 3 次后标 `disabled_unhealthy`。
+- [ ] `POST /api/bridge/:id/test` 接受 `{deep: bool}`。
+- [ ] 错误信息 redact 后写入 `LastError`，不直接 expose adb 路径 / 主机内部信息。
+- [ ] 单元测试：
+  - [ ] `probe_test.go`：fake bridge 模拟 TCP refused / adb fail / device echo timeout 各分支。
+  - [ ] `probe_redact_test.go`：错误字符串 redact 规则。
+- [ ] 验证：unauthorized 设备探针返回 `device_count=1, status=unauthorized`，不报 fail。
+
+## 9. Phase 1d: 前端 bridge 管理 UI
+
+- [ ] `public/static/console.js`：设备列表渲染分组按 bridge_id 分组（当前主列表渲染在 `console.js`，不在 `connect.js`）。`connect.js` 只在连接对话框里附带桥选择下拉。
+- [ ] 新增 `public/static/bridges.js` + 对应 HTML 入口：桥列表、添加桥对话框、test 按钮、deep test 复选框、insecure 红标。
+- [ ] insecure_socat 桥在列表里强制显示 "无鉴权" 警告。
+- [ ] 删除桥时二次确认。
+- [ ] 删除 `bootstrap-env` 桥时弹窗提示 "请改 env 变量"。
+- [ ] 单元测试（jsdom）：
+  - [ ] 桥分组渲染。
+  - [ ] insecure 标记可见性。
+  - [ ] deep test 触发请求带 `deep:true`。
+- [ ] e2e 手动验证：
+  - [ ] 启 webscreen，连两台桥（本地 + Mac socat），UI 显示两组设备。
+  - [ ] 关 Mac 桥的 socat，30s 内 UI 标红。
+  - [ ] 在 UI 点 deep test，返回 per-device 结果。
+
+## 10. 验收 / 最终回归
+
+- [ ] `grep -rn 'exec.Command.*"adb"' sdriver/ webservice/ utils/` 业务代码内为空。
+- [ ] `grep -rn "WEBSCREEN_REMOTE_ADB" sdriver/ webservice/` 业务代码内为空（只剩 main.go bootstrap）。
+- [ ] 单 webscreen 进程 + 两桥 + 两设备同时直播无串流。
+- [ ] 老 `device_id` 链接和书签 100% 兼容。
+- [ ] WebSocket 跨 origin 请求被拒。
+- [ ] audit 日志 24h 不含 token / PIN / shell stdout。
+- [ ] 旧 launcher 启动方式行为不变。
+- [ ] 全部 OpenSpec fixture 对应单测通过。
+- [ ] `webscreen-root-agent` Phase 2 PR 能在不动本变更代码前提下挂接 RootAgentTransport（对接缝预审）。
+
+## 11. 文档
+
+- [ ] 更新 `README.md`：多桥说明、bridge config 文件位置、安全注意。
+- [ ] 新增 `doc/dev/transport.md`：接口三分 + DeviceRef 编码 + Phase 划分。
+- [ ] 新增 `doc/dev/bridges.md`：桥配置示例、insecure 模式注意、Tailscale ACL 模板。
+- [ ] 更新 `launcher/` README：新增 flag、新增 env 兼容说明。

--- a/openspec/changes/device-transport-refactor/tdd.md
+++ b/openspec/changes/device-transport-refactor/tdd.md
@@ -1,0 +1,365 @@
+# TDD: device-transport-refactor
+
+## 原则
+
+先用纯函数 + fake transport 锁住接口契约、DeviceRef 编解码、并发不变量、健康探针分支；再接 fake remote-adb-server 锁住网络层；最后跑真实 socat / 真实设备的 regression。
+
+任何阶段失败都不能用 fallback / cache / global state 掩盖。具体：
+
+- DeviceRef decode 失败必须返回明确 error，禁止静默 fallback 到默认设备。
+- 桥探针失败必须写入 `BridgeStatus.LastError`，禁止用上次成功结果遮盖。
+- transport 调用超时必须返回 error，禁止 retry 隐藏。
+- audit 日志写入失败必须 fail-loud（stderr + 计数器），禁止 swallow。
+
+## 设计门禁验证（红测先行）
+
+四个门禁每个都要有专门的红测，禁止在实现里偷偷绕过。
+
+### 门禁 1: RootAgentTransport 不实现 ADBTransport
+
+红测：
+
+- 编译期：`var _ ADBTransport = (*rootAgentScrcpyTransport)(nil)` 必须**编译失败**。在 Phase 0a 加一个 `compile_assertion_test.go`，里面只放正向断言：
+
+  ```go
+  var (
+      _ DeviceProvider  = (*rootAgentScrcpyTransport)(nil)
+      _ ScrcpyTransport = (*rootAgentScrcpyTransport)(nil)
+      // 注意：故意不断言 ADBTransport
+  )
+  ```
+
+- 运行期：调用者要拿到 ADBTransport 必须通过 type assertion；`rootAgentScrcpyTransport` 在 `BridgeRegistry.GetADB(bridgeID)` 上必须返回 `ErrTransportNotADB`。红测覆盖。
+
+### 门禁 2: socat 兼容期不靠 token
+
+红测：
+
+- `Bridge{SecurityMode: SecurityInsecureSocat}` 在 `Add` 时即使带 token 也必须**丢弃 token + warn**，注册表里 `TokenRef == ""`。
+- `Bridge.Probe` 不读 token。
+- webscreen 启动时如果发现至少一个 insecure 桥，必须打印 `[bridge] WARNING: insecure_socat bridge <id> present; bridge-side ACL required (socat bind, host firewall, Tailscale ACL). webscreen cannot enforce this.`。红测捕获该日志。
+- 该警告与 webscreen 自身的 `-host` bind 参数**无关**：测试覆盖 `-host 0.0.0.0` 和 `-host 100.x.y.z` 两种启动方式，警告内容必须保持一致（不出现"请把 webscreen 端绑到 Tailscale IP"之类误导文案）。
+
+### 门禁 3: 健康检查不用 OpenLocalAbstract
+
+红测：
+
+- `Bridge.Probe` 代码路径里 grep 不到 `OpenLocalAbstract` 调用。用 static check：probe 函数内只允许 `Dial`, `Devices`, `Shell`。
+- 用 fake adb server：返回 `OKAY` for `host:version` / `host:devices-l`，**拒绝** `localabstract:` 请求。probe 必须返回 `TCPOk=true, ADBOk=true, DeviceCount=0`，不报错。
+- 用 fake server：device 列表里包含 `unauthorized` 状态。probe 必须返回 `DeviceCount=1` 不报 fail。
+- deep test：fake shell echo 返回 `alive\n`。probe 必须返回 `LatencyMs > 0` 且无 error。
+
+### 门禁 4: DeviceRef 版本化
+
+红测：
+
+- 字段顺序：`Encode()` 输出 JSON 内字段必须按 ascii 排序（`agent_id`, `bridge_id`, `serial`, `transport`），不同顺序构造的 ref 编码完全相同。
+- `Decode("v2.xxx")` 返回 `ErrUnknownDeviceRefVersion`，不尝试解析。
+- `Decode("v1.<corrupt-base64>")` 返回 `ErrInvalidDeviceRef`。
+- `Decode("v1.<base64 of unknown transport>")` 返回 `ErrUnknownTransport`。
+- `Decode("5f9e7947")` 返回 `DeviceRef{Transport: TransportLocalADB, Serial: "5f9e7947"}` 并打 warn 日志（红测捕获 warn）。
+- legacy 路径只接受 `[A-Za-z0-9._:-]{1,64}`（**`:` 允许**：Wi-Fi ADB serial 常见形如 `192.168.1.100:5555`）。含 `/`、`|`、空白、控制字符（< 0x20 或 0x7f）的输入按 ErrInvalidDeviceRef 拒绝，避免路径注入和分隔符歧义。
+- Display / Model 字段变化不影响 `Encode()` 结果（用同 ref 不同 display 构造 DeviceDescriptor，两个 ref 编码相等）。
+
+## Phase 0a 红测
+
+### 1. DeviceRef 编解码
+
+fixture：`fixtures/device_ref/`
+
+- `local_5f9e7947.json` → `local_adb / / 5f9e7947 / `
+- `remote_mac_coral_5f9e7947.json` → `remote_adb / mac-coral / 5f9e7947 / `
+- `root_agent_xyz.json` → `root_agent / agent-xyz / / xyz`
+- `legacy_bare_serial.txt` → legacy 字符串
+
+红测：
+
+- 每个 fixture round-trip：JSON → DeviceRef → Encode() → Decode() → 等于原 DeviceRef。
+- 各种 reject 用例（见门禁 4）。
+- Encode 输出长度 < 256（避免 URL 过长）。
+
+### 2. ADBTransport 契约 —— CLI exec 与 raw socket 分两类测
+
+按 design.md "adb 可执行注入策略" 二分。两类测试**不重叠**：
+
+**CLI 类（mock exec.Command 捕获 argv）**：
+
+- 用包装层 `execCommand var = exec.Command` 在测试里替换为捕获实现（参考 Go stdlib 测试惯例）。
+- `LocalADBTransport.New(adbPath="/fake/adb")`，调用 `.Devices(ctx)` → 期望 argv `["/fake/adb", "devices", "-l"]`。
+- `LocalADBTransport.Shell(ctx, "5f9e7947", "echo", "hi")` → argv `["/fake/adb", "-s", "5f9e7947", "shell", "echo", "hi"]`。
+- `LocalADBTransport.Push(ctx, "5f9e7947", "src", "dst")` → argv `["/fake/adb", "-s", "5f9e7947", "push", "src", "dst"]`。
+- `RemoteADBTransport.New(host="100.85.28.3", port=15037, adbPath="/fake/adb")` → 任何 CLI 调用 argv 前两段必须是 `["/fake/adb", "-H", "100.85.28.3", "-P", "15037", ...]`。
+- `RemoteADBTransport.Devices` 解析 fake stdout `"5f9e7947 device usb:3-1 product:NE2210 ..."`，返回的 `DeviceDescriptor.Ref.BridgeID` 等于构造时传入的 bridge id。
+- `RemoteADBTransport` 测试**不**起 raw adb-server，全部走 stdout 文本解析。
+- 构造 `RemoteADBTransport` 时不传 `adbPath` → 编译失败或返回 `ErrADBExecutableRequired`。
+
+**Raw socket 类（fake adb-server 监听 TCP，按 host protocol 响应）**：
+
+- 仅覆盖 `OpenLocalAbstract`。
+- fake server 在 `127.0.0.1:0` 监听，按 adb host protocol：
+  - 收到 `0017host:transport:5f9e7947\n` → 回 `OKAY`。
+  - 收到 `0014localabstract:scrcpy_<scid>\n` → 回 `OKAY` 后进入 raw byte 透传模式。
+  - 其他 host 命令返回 `FAIL` + 错误信息。
+- 测试用例：
+  - 正常路径：`RemoteADBTransport.OpenLocalAbstract(ctx, "5f9e7947", "scrcpy_AB12CD34")` → 返回 net.Conn，写入 `"hello"` → fake server 收到 `"hello"`。
+  - serial 不存在：server 返回 `FAIL` → transport 返回 redacted error。
+  - localabstract 不存在：server 返回 `FAIL` → transport 返回 error，且 outer conn 被 close。
+- 不支持的能力（如 LocalADB 用 `OpenLocalAbstract` 但 caps 标 false）调用返回 `ErrCapabilityNotSupported`，不 panic。
+
+### 3. adb 调用收口
+
+静态检查（CI script）：
+
+```bash
+grep -RnE 'exec\.Command(Context)?\([^,]+,\s*"adb"' sdriver/ webservice/ utils/ \
+  | grep -v 'sdriver/scrcpy/local_adb_transport.go' \
+  | grep -v 'sdriver/scrcpy/remote_adb_transport.go'
+# expect empty
+```
+
+加入 PR CI。
+
+### 4. encoder 探测路由
+
+红测：
+
+- 在 fake remote-adb bridge 上挂一个返回 `opus.encoder` 的 shell handler。
+- 创建 `ScrcpyDriver` 时传 `RemoteADBTransport`。
+- `SupportOpusAudio()` 必须**通过 transport** 跑，命中 fake bridge handler，而不是本地 adb。
+- 验证方式：fake remote bridge 设置 `shellCallCount`，断言 `>=1`；同时验证本地 `exec.Command("adb", ...)` 没被调用。
+
+## Phase 0b 红测
+
+### 1. scid 唯一性
+
+- 并发 100 次 `GenerateSCID()`，结果全集无重复。
+- 单 driver 实例 `scid` 字段在构造后不可变；测试反射验证字段非空、非 `"00000000"`。
+
+### 2. 临时目录隔离
+
+- 并发起 4 个 driver，各 `tmpDir` 路径不同。
+- 每个 tmpDir 权限 0700。
+- `Close()` 后 tmpDir 不存在；强 kill 后用 cleanup goroutine 兜底（process exit 时清理）。
+
+### 3. reverse 端口动态分配
+
+- 起 driver A，reverse 用端口 `pA`；起 driver B，reverse 用端口 `pB`；`pA != pB`。
+- 关闭 driver A 后 `pA` 立刻可被新 driver 复用。
+
+### 4. Close 精确 kill
+
+- mock shell 记录所有 kill 命令；`Close()` 必须发 `pkill -f scrcpy-server.*scid=<本 driver 的 scid>`，**不能**发 `pkill app_process`、`pkill -f scrcpy-server`（无 scid 过滤）。
+
+## Phase 0c 红测
+
+### 1. CheckOrigin
+
+- `same-host` 默认：`Origin: http://localhost:8081` + `Host: localhost:8081` → 通过。
+- 跨 origin：`Origin: http://evil.com` + `Host: localhost:8081` → 拒绝（返回 false）。
+- 显式 allowlist `["http://localhost:8081"]`：精确匹配通过；前后空格 / 大小写差异拒绝。
+- `Origin: null`（file:// 或某些跨域场景）→ 拒绝。
+
+### 2. Audit 日志
+
+- 调用 `transport.Shell(ctx, serial, "su", "-c", "echo SECRET")`，audit 条目里 `Summary` 不含 `SECRET`，只含 `shell` 和 redacted summary。
+- token / PIN 注入到任意调用参数，都不进 audit。
+- shell stdout 不进 audit（只记 exit code / 时长）。
+- audit 写入失败时 stderr 报错且 metric `audit_write_failures` +1，不 swallow。
+
+### 3. transport timeout
+
+- fake transport `Shell` 故意 sleep 10s，外层 `WithTimeout(5s)` → 必须返回 `context.DeadlineExceeded` 包装错误，bridge `LastError` 包含 `timeout`。
+- 调用方可传更长 ctx 覆盖默认 5s（不是硬编码）。
+
+### 4. GetADBPath 收敛
+
+- `RemoteADBTransport` 构造 + Devices 调用 → grep 不到 `GetADBPath` 调用 stack。
+- `LocalADBTransport.New()` 未找到 adb 时下载到 `os.UserCacheDir()/webscreen/adb/`，**不写 cwd**。
+- 下载文件名含版本号，不覆盖既有版本。
+
+## Phase 0d 红测
+
+### 1. handleScreen.go subscriber key
+
+- POST 含 `device_ref: "v1.xxx"` → subscriber key 等于该 ref encoded。
+- POST 仅含 legacy `device_id: "5f9e7947"`（无 device_ref）→ subscriber key 等于 `DeviceRef{Transport:local_adb, Serial:"5f9e7947"}.Encode()`。
+- 同一台设备两种 payload 同时连入，落到同一个 subscriber slot，不会被当成两台设备。
+- 返回的 `DeviceInfo` JSON 必须**同时**包含 `device_id`（legacy serial）、`device_ref`（v1 编码）、`bridge_id`、`display`、`model` 五个字段。
+
+### 2. localStorage 迁移（按真实结构）
+
+当前结构（`public/static/console.js:6-7`）：
+
+```js
+localStorage.webscreen_device_configs = JSON.stringify({
+    "5f9e7947": { pin: "...", display: "OnePlus", ... },
+    "abc123":   { ... }
+});
+localStorage.webscreen_ignored_devices = JSON.stringify(["serial-x", "serial-y"]);
+```
+
+jsdom 测试用例：
+
+- **配置对象迁移**：
+  - 注入上面的 `webscreen_device_configs`。
+  - 跑 `migrateDeviceConfigs()`。
+  - 断言每个 entry 新增 `_ref` 字段，值是 `v1.` 编码的 DeviceRef（Transport=local_adb, Serial=该 key）。
+  - 断言老 key（`"5f9e7947"`, `"abc123"`）**仍在**，配置内容不变。
+  - 断言 `localStorage.webscreen_storage_schema_version === "2"`。
+- **忽略列表迁移**：
+  - 注入 `webscreen_ignored_devices = ["serial-x", "serial-y"]`。
+  - 跑迁移。
+  - 断言 `webscreen_ignored_device_refs = [v1.<x>, v1.<y>]`，老数组保留。
+- **幂等**：
+  - 已迁移过的 localStorage 再跑一次迁移 → 状态完全不变（含字段顺序、字符串内容）。
+- **30 天清理（未来 Phase）**：
+  - 注入 `webscreen_storage_migrated_at = 30 天前时间戳`。
+  - 调用 `cleanupLegacyDeviceKeys()`（本 Phase 仅写函数桩，下一 Phase 启用）。
+  - 当前 Phase 测试：函数存在、被调用时不抛错。
+- **新增 entry 后兼容**：
+  - 迁移完成后，用户在新前端 rename 设备 → 既写 `_ref` 字段也写 legacy serial 字段，旧前端打开仍可见。
+
+### 3. 老链接兼容（本 Phase 不做 301）
+
+- GET `/screen/5f9e7947` → 200 OK，subscriber key 走 legacy 升格成 local_adb ref。
+- GET `/screen/v1.invalid_payload` → 400 `invalid_device_ref`。
+- GET `/screen/../etc/passwd` → 400 拒绝（路径含特殊字符）。
+- 301 跳转留待后续 Phase（在 device_id 字段最终下线前不强制 301，避免老书签突然失效）。
+
+## Phase 1a 红测
+
+### 1. 持久化
+
+- 写入 `bridges.json` 后立刻读回，内容相同。
+- 文件权限 0600；改成 0644 后启动时 `refuse to start` 并提示。
+- 文件 version != 1 时返回 `unsupported_config_version`。
+- 写入失败（磁盘满 / 权限错）时返回明确 error，不 swallow。
+
+### 2. Bootstrap ephemeral
+
+- 设 `WEBSCREEN_REMOTE_ADB=1, HOST, PORT`，启动后 registry 包含 `bootstrap-env` bridge，`bridges.json` 不变。
+- 进程退出，重启后 ephemeral 消失（如 env 仍在，新一次启动再注册）。
+- 持久 bridge 与 ephemeral 同 ID 时拒绝持久化（保留 ID 名 `bootstrap-env`）。
+
+### 3. Token 存储
+
+- Windows：调用 DPAPI 模拟；失败 fallback 0600 文件。
+- 文件 fallback 权限校验。
+- `insecure_socat` bridge 即使带 token，token 也不被存储（红测）。
+
+## Phase 1b 红测
+
+### 1. CRUD API
+
+- `POST /api/bridge/add` 缺字段返回 400。
+- 重复 add 同 host:port 返回 409 conflict。
+- DELETE `bootstrap-env` 返回 409 + 提示。
+- 全部 API 在无 PIN cookie 时 401。
+
+### 2. /api/device/list fan-out
+
+- 3 桥并发：A 1s 返回 2 设备，B 1s 返回 1 设备，C 超时 3s。
+- 总响应时间 ≤ 3.5s。
+- 返回设备总数 3，每个设备项带正确 `device_ref`（含对应 bridge_id）。
+- C 桥状态标记为 `LastError: "timeout"`，但不阻塞 A/B 返回。
+
+### 3. 序列化稳定
+
+- `GET /api/bridge/list` 响应 JSON key 顺序稳定（按 ID asc）。
+- token 字段绝不出现在响应里。
+
+## Phase 1c 红测
+
+### 1. 三段式 probe
+
+每条用 fake bridge 单独覆盖：
+
+- TCP refused → `TCPOk=false, ADBOk=false`。
+- TCP ok + adb fail（返回 `FAIL`）→ `TCPOk=true, ADBOk=false, LastError` 含 redacted adb 错误。
+- TCP ok + adb ok + 空设备 → `TCPOk=true, ADBOk=true, DeviceCount=0, LastError=""`。
+- TCP ok + adb ok + 1 unauthorized → `DeviceCount=1`，不报 fail。
+- deep + per-device shell timeout → `LastError` 含设备 serial（但不含 stdout）。
+
+### 2. 后台 probe goroutine
+
+- 起 webscreen，2 桥 enabled，30s 后两桥 status 都更新。
+- 桥连续 3 次 fail，状态变 `disabled_unhealthy`，UI 标灰。
+- 一旦恢复，下一次 probe 标回 enabled。
+
+### 3. Error redact
+
+- redact 规则：去除 IP、token、文件路径中的用户名。
+- 红测：错误字符串 `dial tcp 100.85.28.3:15037: connection refused` → redact 后只保留 `connection refused` + bridge id。
+
+## Phase 1d 红测（jsdom）
+
+- 桥列表渲染：3 桥按 id asc。
+- insecure 桥渲染 `aria-label="unauthenticated bridge"` + 红色徽标。
+- deep test 按钮点击发 `POST /api/bridge/:id/test` body `{"deep":true}`。
+- 删除 bootstrap-env 桥按钮 disabled + tooltip。
+- 添加桥表单：security_mode = `insecure_socat` 时 token 输入框 disabled + 提示。
+
+## 集成验收
+
+### 双桥双设备
+
+- 启动 webscreen，注册：
+  - bridge A：本机 USB 直连一台 emulator。
+  - bridge B：100.85.28.3:15037 socat。
+- `/api/device/list` 返回 2 个设备，各自 `device_ref` 不同 bridge_id。
+- 同时打开两个 stream 页面，两条 scrcpy 视频流并行 60s 无串流、无 driver 之间 crash。
+- 关闭其中一个 stream，另一个不受影响。
+- 看 audit 日志：双 stream 的命令各自标 bridge id，无串。
+
+### 老链接兼容
+
+- 用户 bookmark `http://localhost:8081/screen/5f9e7947` → 200 OK 正常进入 stream（subscriber key 走 legacy 升格到 `DeviceRef{Transport:local_adb, Serial:"5f9e7947"}`）。本变更**不做** 301 跳转 —— 老书签必须继续可用。
+
+### CheckOrigin
+
+- `curl -H "Origin: http://evil.com" ws://localhost:8081/screen/ws` → 403。
+
+### 桥故障
+
+- 启动后 kill Mac socat。30s 内 UI 桥 B 标红，桥 B 设备从 device list 消失或标 stale。
+- 恢复 socat。下个 probe 周期内桥 B 标回 ok。
+
+## 不测试范围
+
+- root-agent transport（由 `webscreen-root-agent` 变更负责测试）。
+- WebRTC 编解码（不在本变更范围）。
+- linux driver（不在本变更范围）。
+- 媒体下沉到桥（暂缓）。
+
+## Fixture 目录
+
+```text
+openspec/changes/device-transport-refactor/fixtures/
+  device_ref/
+    local_5f9e7947.json
+    remote_mac_coral_5f9e7947.json
+    root_agent_xyz.json
+    legacy_bare_serial.txt
+    invalid_v2.json
+    invalid_corrupt_base64.json
+    invalid_unknown_transport.json
+    invalid_path_injection.json
+  bridge_config/
+    valid_minimal.json
+    valid_dual_bridge.json
+    invalid_version.json
+    invalid_bad_perm.json
+  probe_responses/
+    tcp_refused.txt
+    adb_fail.bin
+    adb_ok_empty.bin
+    adb_ok_one_unauthorized.bin
+    deep_shell_alive.txt
+  audit_redact/
+    contains_token.txt
+    contains_pin.txt
+    contains_stdout.txt
+    expected_redacted.txt
+```
+
+实现 PR 时按 Phase 复制对应 fixture 到测试目录；OpenSpec fixture 作为协议金标准。

--- a/sdriver/device_ref.go
+++ b/sdriver/device_ref.go
@@ -1,0 +1,116 @@
+package sdriver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+)
+
+type TransportID string
+type BridgeID string
+
+const (
+	TransportLocalADB  TransportID = "local_adb"
+	TransportRemoteADB TransportID = "remote_adb"
+	TransportRootAgent TransportID = "root_agent"
+)
+
+var (
+	ErrInvalidDeviceRef        = errors.New("invalid device ref")
+	ErrUnknownDeviceRefVersion = errors.New("unknown device ref version")
+)
+
+var legacyADBSerialRE = regexp.MustCompile(`^[A-Za-z0-9._:-]{1,64}$`)
+
+type DeviceRef struct {
+	AgentID   string      `json:"agent_id"`
+	BridgeID  BridgeID    `json:"bridge_id"`
+	Serial    string      `json:"serial"`
+	Transport TransportID `json:"transport"`
+}
+
+func (r DeviceRef) Validate() error {
+	switch r.Transport {
+	case TransportLocalADB:
+		if r.Serial == "" || r.BridgeID != "" || r.AgentID != "" {
+			return fmt.Errorf("%w: invalid local_adb fields", ErrInvalidDeviceRef)
+		}
+	case TransportRemoteADB:
+		if r.Serial == "" || r.BridgeID == "" || r.AgentID != "" {
+			return fmt.Errorf("%w: invalid remote_adb fields", ErrInvalidDeviceRef)
+		}
+	case TransportRootAgent:
+		if r.AgentID == "" || r.Serial != "" {
+			return fmt.Errorf("%w: invalid root_agent fields", ErrInvalidDeviceRef)
+		}
+	default:
+		return fmt.Errorf("%w: invalid transport %q", ErrInvalidDeviceRef, r.Transport)
+	}
+	return nil
+}
+
+func (r DeviceRef) Encode() string {
+	if err := r.Validate(); err != nil {
+		return ""
+	}
+	payload, err := json.Marshal(r)
+	if err != nil {
+		return ""
+	}
+	return "v1." + base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func DecodeDeviceRef(value string) (DeviceRef, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return DeviceRef{}, fmt.Errorf("%w: empty device ref", ErrInvalidDeviceRef)
+	}
+	if strings.HasPrefix(value, "v1.") {
+		return decodeDeviceRefV1(strings.TrimPrefix(value, "v1."))
+	}
+	if strings.Contains(value, ".") {
+		prefix, _, _ := strings.Cut(value, ".")
+		if strings.HasPrefix(prefix, "v") {
+			return DeviceRef{}, fmt.Errorf("%w: %s", ErrUnknownDeviceRefVersion, prefix)
+		}
+	}
+	return DecodeLegacyDeviceRef(value)
+}
+
+func DecodeLegacyDeviceRef(serial string) (DeviceRef, error) {
+	if !legacyADBSerialRE.MatchString(serial) {
+		return DeviceRef{}, fmt.Errorf("%w: invalid legacy adb serial", ErrInvalidDeviceRef)
+	}
+	log.Printf("[device_ref] legacy adb serial %q upgraded to local_adb DeviceRef", serial)
+	return DeviceRef{Transport: TransportLocalADB, Serial: serial}, nil
+}
+
+func decodeDeviceRefV1(encoded string) (DeviceRef, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return DeviceRef{}, fmt.Errorf("%w: invalid base64", ErrInvalidDeviceRef)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return DeviceRef{}, fmt.Errorf("%w: invalid json", ErrInvalidDeviceRef)
+	}
+	for key := range raw {
+		switch key {
+		case "agent_id", "bridge_id", "serial", "transport":
+		default:
+			return DeviceRef{}, fmt.Errorf("%w: unknown field %q", ErrInvalidDeviceRef, key)
+		}
+	}
+	var ref DeviceRef
+	if err := json.Unmarshal(payload, &ref); err != nil {
+		return DeviceRef{}, fmt.Errorf("%w: invalid payload", ErrInvalidDeviceRef)
+	}
+	if err := ref.Validate(); err != nil {
+		return DeviceRef{}, err
+	}
+	return ref, nil
+}

--- a/sdriver/device_ref_test.go
+++ b/sdriver/device_ref_test.go
@@ -1,0 +1,105 @@
+package sdriver
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeviceRefRoundTripRemoteADB(t *testing.T) {
+	ref := DeviceRef{
+		BridgeID:  "mac-coral",
+		Serial:    "5f9e7947",
+		Transport: TransportRemoteADB,
+	}
+
+	encoded := ref.Encode()
+	if !strings.HasPrefix(encoded, "v1.") {
+		t.Fatalf("encoded ref should have v1 prefix: %q", encoded)
+	}
+	decoded, err := DecodeDeviceRef(encoded)
+	if err != nil {
+		t.Fatalf("DecodeDeviceRef returned error: %v", err)
+	}
+	if decoded != ref {
+		t.Fatalf("decoded ref mismatch: got %#v want %#v", decoded, ref)
+	}
+}
+
+func TestDeviceRefFixtureRoundTrips(t *testing.T) {
+	fixtures, err := filepath.Glob(filepath.FromSlash("../openspec/changes/device-transport-refactor/fixtures/device_ref/*.json"))
+	if err != nil {
+		t.Fatalf("fixture glob failed: %v", err)
+	}
+	if len(fixtures) == 0 {
+		t.Fatalf("no device_ref fixtures found")
+	}
+	for _, fixture := range fixtures {
+		t.Run(filepath.Base(fixture), func(t *testing.T) {
+			data, err := os.ReadFile(fixture)
+			if err != nil {
+				t.Fatalf("read fixture failed: %v", err)
+			}
+			var ref DeviceRef
+			if err := json.Unmarshal(data, &ref); err != nil {
+				t.Fatalf("unmarshal fixture failed: %v", err)
+			}
+			encoded := ref.Encode()
+			if encoded == "" {
+				t.Fatalf("Encode returned empty string for %#v", ref)
+			}
+			decoded, err := DecodeDeviceRef(encoded)
+			if err != nil {
+				t.Fatalf("DecodeDeviceRef returned error: %v", err)
+			}
+			if decoded != ref {
+				t.Fatalf("decoded ref mismatch: got %#v want %#v", decoded, ref)
+			}
+		})
+	}
+}
+
+func TestDeviceRefJSONFieldOrder(t *testing.T) {
+	ref := DeviceRef{
+		BridgeID:  "mac-coral",
+		Serial:    "5f9e7947",
+		Transport: TransportRemoteADB,
+	}
+
+	encoded := ref.Encode()
+	const want = "v1.eyJhZ2VudF9pZCI6IiIsImJyaWRnZV9pZCI6Im1hYy1jb3JhbCIsInNlcmlhbCI6IjVmOWU3OTQ3IiwidHJhbnNwb3J0IjoicmVtb3RlX2FkYiJ9"
+	if encoded != want {
+		t.Fatalf("encoded ref mismatch:\ngot  %s\nwant %s", encoded, want)
+	}
+}
+
+func TestDeviceRefLegacySerialAllowsWifiADBColon(t *testing.T) {
+	ref, err := DecodeDeviceRef("192.168.1.100:5555")
+	if err != nil {
+		t.Fatalf("DecodeDeviceRef returned error: %v", err)
+	}
+	if ref.Transport != TransportLocalADB || ref.Serial != "192.168.1.100:5555" {
+		t.Fatalf("legacy ref mismatch: %#v", ref)
+	}
+}
+
+func TestDeviceRefRejectsUnknownVersion(t *testing.T) {
+	_, err := DecodeDeviceRef("v2.abc")
+	if !errors.Is(err, ErrUnknownDeviceRefVersion) {
+		t.Fatalf("expected ErrUnknownDeviceRefVersion, got %v", err)
+	}
+}
+
+func TestDeviceRefRejectsInvalidLegacySerial(t *testing.T) {
+	for _, input := range []string{"serial/with/slash", "serial|pipe", "serial with space", "serial\x7f"} {
+		t.Run(input, func(t *testing.T) {
+			_, err := DecodeDeviceRef(input)
+			if !errors.Is(err, ErrInvalidDeviceRef) {
+				t.Fatalf("expected ErrInvalidDeviceRef, got %v", err)
+			}
+		})
+	}
+}

--- a/sdriver/scrcpy/adb.go
+++ b/sdriver/scrcpy/adb.go
@@ -4,61 +4,68 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os/exec"
 	"strings"
 	"time"
 )
 
 type ADBClient struct {
-	deviceSerial string // 设备的IP地址或序列号
+	deviceSerial string
 	scid         string
 	remotePath   string
 	ctx          context.Context
 	cancel       context.CancelFunc
+	transport    ADBTransport
+	transportErr error
 }
 
-// NewClient 创建一个新的 ADB 客户端结构体.
-// 如果 address 为空字符串，则表示使用默认设备.
 func NewADBClient(deviceSerial string, scid string, parentCtx context.Context) *ADBClient {
 	ctx, cancel := context.WithCancel(parentCtx)
-	return &ADBClient{deviceSerial: deviceSerial, scid: scid, ctx: ctx, cancel: cancel}
-}
-
-// 显式停止服务的方法
-func (c *ADBClient) Stop() {
-	if c.scid != "" {
-		c.ReverseRemove(fmt.Sprintf("localabstract:scrcpy_%s", c.scid))
+	transport, err := NewADBTransportFromEnvironment()
+	return &ADBClient{
+		deviceSerial: deviceSerial,
+		scid:         scid,
+		ctx:          ctx,
+		cancel:       cancel,
+		transport:    transport,
+		transportErr: err,
 	}
-	c.cancel() // 这会触发所有绑定了该 ctx 的命令被 Kill
 }
 
-// Push 将本地文件推送到设备上
+func (c *ADBClient) Stop() {
+	if c.scid != "" && c.transportErr == nil && c.transport != nil && c.transport.Capabilities().CanReverse {
+		_ = c.ReverseRemove(fmt.Sprintf("localabstract:scrcpy_%s", c.scid))
+	}
+	c.cancel()
+}
+
 func (c *ADBClient) PushScrcpyServer(localPath string, remotePath string) error {
 	if c.remotePath == "" {
 		c.remotePath = "/data/local/tmp/scrcpy-server"
 	}
-	err := c.adb("push", localPath, c.remotePath)
-	if err != nil {
+	if c.transportErr != nil {
+		return c.transportErr
+	}
+	if err := c.transport.Push(c.ctx, c.deviceSerial, localPath, c.remotePath); err != nil {
 		return fmt.Errorf("ADB Push failed: %v", err)
 	}
-	// c.ScrcpyParams.CLASSPATH = remotePath
 	return nil
 }
 
-func (c *ADBClient) Reverse(local, remote string) error {
-	// c.ReverseRemove(local)
-	err := c.adb("reverse", local, remote)
-	if err != nil {
+func (c *ADBClient) Reverse(remote, local string) error {
+	if c.transportErr != nil {
+		return c.transportErr
+	}
+	if err := c.transport.Reverse(c.ctx, c.deviceSerial, remote, local); err != nil {
 		return fmt.Errorf("ADB Reverse failed: %v", err)
 	}
 	return nil
 }
 
-func (c *ADBClient) ReverseRemove(local string) error {
-	c.adb("reverse", "--remove", local)
-	// if err != nil {
-	// 	return fmt.Errorf("ADB Reverse Remove failed: %v", err)
-	// }
+func (c *ADBClient) ReverseRemove(remote string) error {
+	if c.transportErr != nil || c.transport == nil {
+		return c.transportErr
+	}
+	_ = c.transport.ReverseRemove(c.ctx, c.deviceSerial, remote)
 	return nil
 }
 
@@ -66,75 +73,50 @@ func (c *ADBClient) StartScrcpyServer(options map[string]string) error {
 	cmdStr := toScrcpyCommand(options)
 
 	go func() {
-		time.Sleep(time.Second * 2) // 给一点时间让 reverse tunnel 生效
+		time.Sleep(2 * time.Second)
 		log.Printf("Starting scrcpy server with command: %s", cmdStr)
-		err := c.adb("shell", cmdStr)
-		if err != nil {
+		if c.transportErr != nil {
+			log.Printf("Failed to initialize adb transport: %v", c.transportErr)
+			return
+		}
+		if _, err := c.transport.Shell(c.ctx, c.deviceSerial, cmdStr); err != nil {
 			log.Printf("Failed to run adb shell command: %v", err)
 			return
-		} else {
-			log.Println("Scrcpy server exited normally")
 		}
+		log.Println("Scrcpy server exited normally")
 	}()
 
-	// 这里我们无法立即知道是否成功，因为 Shell 命令会阻塞
-	// 真正的“成功”标志是我们的 Listener Accept 到了连接
 	return nil
 }
 
-func (c *ADBClient) adb(args ...string) error {
-	// 如果没有指定设备地址，则使用默认 adb 命令
-	log.Printf("Executing on device %s: %s", c.deviceSerial, args)
-	if c.deviceSerial == "" {
-		return ExecADB(c.ctx, args...)
-	}
-	// 否则，添加 -s 参数指定设备
-	return ExecADB(c.ctx, append([]string{"-s", c.deviceSerial}, args...)...)
-}
-
 func (c *ADBClient) SupportOpusAudio() bool {
-	// 1. 构造 shell 命令
 	cmdStr := "grep -i 'opus.encoder' " +
 		"/system/etc/media_codecs*.xml " +
 		"/system_ext/etc/media_codecs*.xml " +
-		"/vendor/etc/media_codecs*.xml " + //常见安卓真机
+		"/vendor/etc/media_codecs*.xml " +
 		"/vendor/odm/etc/media_codecs*.xml " +
 		"/odm/etc/media_codecs*.xml " +
 		"/product/etc/media_codecs*.xml " +
-		"/apex/com.android.media.swcodec/etc/media_codecs*.xml " + //通用
+		"/apex/com.android.media.swcodec/etc/media_codecs*.xml " +
 		"/apex/com.android.media/etc/media_codecs*.xml " +
 		" 2>/dev/null || true"
-	//扩展路径，编码器的参数文件路径不同设备不同，不添加"||true" 会导致返回状态码2无法正常返回stdout
 
-	// 2. 准备 adb 参数
-	var args []string
-	if c.deviceSerial != "" {
-		args = append(args, "-s", c.deviceSerial)
+	if c.transportErr != nil {
+		log.Printf("Failed to initialize adb transport: %v", c.transportErr)
+		return false
 	}
-	args = append(args, "shell", cmdStr)
-
-	// 3. 执行命令并捕获输出
-	// 使用 c.ctx 以便在父 Context 取消时能够中止命令
-	cmd := exec.CommandContext(c.ctx, "adb", args...)
-
-	output, err := cmd.CombinedOutput() // 同时获取 stdout 和 stderr
+	output, err := c.transport.Shell(c.ctx, c.deviceSerial, cmdStr)
 	if err != nil {
-		// 命令执行失败（可能是 adb 没连接，或者 app_process 报错）
 		log.Printf("Failed to check audio encoders: %v", err)
 		return false
 	}
 
-	// 4. 检查输出中是否包含 "opus.encoder"
 	outputStr := string(output)
-
-	// 调试日志：可选，查看设备实际返回了什么
 	log.Printf("opus Encoder : %s", outputStr)
-
 	return strings.Contains(outputStr, "opus.encoder")
 }
 
 func (c *ADBClient) SupportedEncoderList() []string {
-	// 1. 构造 shell 命令
 	cmdStr := "grep -E '<MediaCodec name=\"[^\"]*encoder[^\"]*\"' " +
 		"/system/etc/media_codecs*.xml " +
 		"/system_ext/etc/media_codecs*.xml " +
@@ -146,42 +128,36 @@ func (c *ADBClient) SupportedEncoderList() []string {
 		"/apex/com.android.media/etc/media_codecs*.xml " +
 		" 2>/dev/null || true"
 
-	var args []string
-	if c.deviceSerial != "" {
-		args = append(args, "-s", c.deviceSerial)
+	if c.transportErr != nil {
+		log.Printf("Failed to initialize adb transport: %v", c.transportErr)
+		return nil
 	}
-	args = append(args, "shell", cmdStr)
-
-	cmd := exec.CommandContext(c.ctx, "adb", args...)
-	output, err := cmd.CombinedOutput()
+	output, err := c.transport.Shell(c.ctx, c.deviceSerial, cmdStr)
 	if err != nil {
 		log.Printf("Failed to get supported encoders: %v", err)
 		return nil
 	}
 
-	outputStr := string(output)
 	var encoders []string
-	lines := strings.Split(outputStr, "\n")
-	for _, line := range lines {
-		// Example: <MediaCodec name="c2.rk.hevc.encoder" type="video/hevc" ...>
+	for _, line := range strings.Split(string(output), "\n") {
 		if idx := strings.Index(line, "name=\""); idx != -1 {
-			start := idx + 6
+			start := idx + len("name=\"")
 			if end := strings.Index(line[start:], "\""); end != -1 {
 				name := line[start : start+end]
-				// 可以在这里只保留 video 相关的 encoder，比如包含 video 或 hevc/avc 的等，
-				// 这里做个简单过滤以避免重复和非 encoder 实体
-				found := false
-				for _, e := range encoders {
-					if e == name {
-						found = true
-						break
-					}
-				}
-				if !found && strings.Contains(strings.ToLower(name), "encoder") {
+				if strings.Contains(strings.ToLower(name), "encoder") && !containsString(encoders, name) {
 					encoders = append(encoders, name)
 				}
 			}
 		}
 	}
 	return encoders
+}
+
+func containsString(values []string, candidate string) bool {
+	for _, value := range values {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
 }

--- a/sdriver/scrcpy/adb_devices_parse.go
+++ b/sdriver/scrcpy/adb_devices_parse.go
@@ -1,0 +1,64 @@
+package scrcpy
+
+import (
+	"strings"
+	"webscreen/sdriver"
+)
+
+func parseADBDevices(output []byte, transport sdriver.TransportID, bridgeID sdriver.BridgeID) []DeviceDescriptor {
+	var devices []DeviceDescriptor
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "List of devices attached") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		serial := fields[0]
+		status := parseADBStatus(fields[1])
+		model := parseADBModel(fields[2:])
+		ref := sdriver.DeviceRef{
+			BridgeID:  bridgeID,
+			Serial:    serial,
+			Transport: transport,
+		}
+		if transport == sdriver.TransportLocalADB {
+			ref.BridgeID = ""
+		}
+
+		devices = append(devices, DeviceDescriptor{
+			Ref:       ref,
+			Serial:    serial,
+			Model:     model,
+			Status:    status,
+			Transport: transport,
+			BridgeID:  ref.BridgeID,
+		})
+	}
+	return devices
+}
+
+func parseADBStatus(status string) DeviceStatus {
+	switch status {
+	case "device":
+		return DeviceConnected
+	case "unauthorized":
+		return DeviceUnauthorized
+	case "offline":
+		return DeviceOffline
+	default:
+		return DeviceUnknown
+	}
+}
+
+func parseADBModel(fields []string) string {
+	for _, field := range fields {
+		if model, ok := strings.CutPrefix(field, "model:"); ok {
+			return model
+		}
+	}
+	return ""
+}

--- a/sdriver/scrcpy/adb_devices_parse_test.go
+++ b/sdriver/scrcpy/adb_devices_parse_test.go
@@ -1,0 +1,39 @@
+package scrcpy
+
+import (
+	"testing"
+	"webscreen/sdriver"
+)
+
+func TestParseADBDevicesLocal(t *testing.T) {
+	output := []byte("List of devices attached\n5f9e7947 device usb:3-1 product:NE2210 model:NE2210 device:OP515BL1\nemulator-5554 offline\n")
+
+	devices := parseADBDevices(output, sdriver.TransportLocalADB, "")
+	if len(devices) != 2 {
+		t.Fatalf("len(devices) = %d, want 2", len(devices))
+	}
+	if devices[0].Ref.Transport != sdriver.TransportLocalADB || devices[0].Ref.Serial != "5f9e7947" {
+		t.Fatalf("unexpected first ref: %#v", devices[0].Ref)
+	}
+	if devices[0].Model != "NE2210" {
+		t.Fatalf("model = %q, want NE2210", devices[0].Model)
+	}
+	if devices[1].Status != DeviceOffline {
+		t.Fatalf("status = %q, want offline", devices[1].Status)
+	}
+}
+
+func TestParseADBDevicesRemoteBridgeID(t *testing.T) {
+	output := []byte("List of devices attached\n5f9e7947 unauthorized model:NE2210\n")
+
+	devices := parseADBDevices(output, sdriver.TransportRemoteADB, "mac-coral")
+	if len(devices) != 1 {
+		t.Fatalf("len(devices) = %d, want 1", len(devices))
+	}
+	if devices[0].Ref.BridgeID != "mac-coral" || devices[0].BridgeID != "mac-coral" {
+		t.Fatalf("bridge mismatch: %#v", devices[0])
+	}
+	if devices[0].Status != DeviceUnauthorized {
+		t.Fatalf("status = %q, want unauthorized", devices[0].Status)
+	}
+}

--- a/sdriver/scrcpy/adb_scrcpy_transport.go
+++ b/sdriver/scrcpy/adb_scrcpy_transport.go
@@ -1,0 +1,25 @@
+package scrcpy
+
+import (
+	"context"
+	"webscreen/sdriver"
+)
+
+type adbScrcpyTransport struct {
+	adb ADBTransport
+}
+
+func newADBScrcpyTransport(adb ADBTransport) *adbScrcpyTransport {
+	return &adbScrcpyTransport{adb: adb}
+}
+
+func (t *adbScrcpyTransport) Devices(ctx context.Context) ([]DeviceDescriptor, error) {
+	return t.adb.Devices(ctx)
+}
+
+func (t *adbScrcpyTransport) StartScrcpySession(ctx context.Context, ref sdriver.DeviceRef, opts ScrcpyOptions) (*ScrcpySession, error) {
+	if opts.SCID == "" {
+		return nil, ErrSCIDRequired
+	}
+	return nil, ErrCapabilityNotSupported
+}

--- a/sdriver/scrcpy/adb_transport_exec.go
+++ b/sdriver/scrcpy/adb_transport_exec.go
@@ -1,0 +1,22 @@
+package scrcpy
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+var execCommandContext = exec.CommandContext
+
+func runADBCommand(ctx context.Context, adbExecutable string, args ...string) ([]byte, error) {
+	if strings.TrimSpace(adbExecutable) == "" {
+		return nil, ErrADBExecutableRequired
+	}
+	cmd := execCommandContext(ctx, adbExecutable, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("%w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}

--- a/sdriver/scrcpy/adb_transport_exec_test.go
+++ b/sdriver/scrcpy/adb_transport_exec_test.go
@@ -1,0 +1,109 @@
+package scrcpy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"webscreen/sdriver"
+)
+
+func TestLocalADBTransportShellRoutesSerial(t *testing.T) {
+	argFile := installADBExecHelper(t, "")
+
+	transport, err := NewLocalADBTransport("/fake/adb")
+	if err != nil {
+		t.Fatalf("NewLocalADBTransport returned error: %v", err)
+	}
+	if _, err := transport.Shell(context.Background(), "5f9e7947", "echo", "hi"); err != nil {
+		t.Fatalf("Shell returned error: %v", err)
+	}
+
+	got := readExecHelperArgs(t, argFile)
+	want := "/fake/adb\x00-s\x005f9e7947\x00shell\x00echo\x00hi"
+	if got != want {
+		t.Fatalf("argv mismatch:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestRemoteADBTransportPrefixesHostPortForCLI(t *testing.T) {
+	argFile := installADBExecHelper(t, "5f9e7947 device model:NE2210\n")
+
+	transport, err := NewRemoteADBTransport("mac-coral", "100.85.28.3", 15037, "/fake/adb")
+	if err != nil {
+		t.Fatalf("NewRemoteADBTransport returned error: %v", err)
+	}
+	devices, err := transport.Devices(context.Background())
+	if err != nil {
+		t.Fatalf("Devices returned error: %v", err)
+	}
+	if len(devices) != 1 || devices[0].Ref.BridgeID != sdriver.BridgeID("mac-coral") {
+		t.Fatalf("unexpected devices: %#v", devices)
+	}
+
+	got := readExecHelperArgs(t, argFile)
+	want := "/fake/adb\x00-H\x00100.85.28.3\x00-P\x0015037\x00devices\x00-l"
+	if got != want {
+		t.Fatalf("argv mismatch:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestRemoteADBTransportRequiresExplicitADBExecutable(t *testing.T) {
+	_, err := NewRemoteADBTransport("mac-coral", "100.85.28.3", 15037, "")
+	if !errors.Is(err, ErrADBExecutableRequired) {
+		t.Fatalf("expected ErrADBExecutableRequired, got %v", err)
+	}
+}
+
+func installADBExecHelper(t *testing.T, stdout string) string {
+	t.Helper()
+
+	old := execCommandContext
+	argFile := t.TempDir() + string(os.PathSeparator) + "argv.txt"
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		helperArgs := append([]string{"-test.run=TestADBExecHelper", "--", name}, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], helperArgs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_ADB_EXEC_HELPER=1",
+			"ADB_EXEC_HELPER_ARG_FILE="+argFile,
+			"ADB_EXEC_HELPER_STDOUT="+stdout,
+		)
+		return cmd
+	}
+	t.Cleanup(func() {
+		execCommandContext = old
+	})
+	return argFile
+}
+
+func readExecHelperArgs(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read helper args: %v", err)
+	}
+	return string(data)
+}
+
+func TestADBExecHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_ADB_EXEC_HELPER") != "1" {
+		return
+	}
+	sep := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep == -1 {
+		fmt.Fprint(os.Stderr, "missing --")
+		os.Exit(2)
+	}
+	_ = os.WriteFile(os.Getenv("ADB_EXEC_HELPER_ARG_FILE"), []byte(strings.Join(os.Args[sep+1:], "\x00")), 0600)
+	fmt.Print(os.Getenv("ADB_EXEC_HELPER_STDOUT"))
+	os.Exit(0)
+}

--- a/sdriver/scrcpy/adb_transport_factory.go
+++ b/sdriver/scrcpy/adb_transport_factory.go
@@ -1,0 +1,15 @@
+package scrcpy
+
+import "webscreen/sdriver"
+
+func NewADBTransportFromEnvironment() (ADBTransport, error) {
+	local, err := NewLocalADBTransport()
+	if err != nil {
+		return nil, err
+	}
+	host, port, ok := remoteADBEndpoint()
+	if !ok {
+		return local, nil
+	}
+	return NewRemoteADBTransport(sdriver.BridgeID("bootstrap-env"), host, port, local.ADBExecutable)
+}

--- a/sdriver/scrcpy/adbutils.go
+++ b/sdriver/scrcpy/adbutils.go
@@ -1,37 +1,19 @@
 package scrcpy
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
-	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"time"
-	"webscreen/utils"
 )
-
-func ExecADB(ctx context.Context, args ...string) error {
-	adbPath, err := utils.GetADBPath()
-	if err != nil {
-		return err
-	}
-	cmd := exec.CommandContext(ctx, adbPath, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	return err
-}
 
 func GenerateSCID() string {
 	seed := time.Now().UnixNano() + rand.Int63()
 	r := rand.New(rand.NewSource(seed))
-	// 生成31位随机整数
 	return strconv.FormatInt(int64(r.Uint32()&0x7FFFFFFF), 16)
 }
 
-// 将ScrcpyParams转为 key=value 格式的参数列表
 func scrcpyParamsToArgs(params map[string]string) []string {
 	var args []string
 	keys := []string{
@@ -46,6 +28,7 @@ func scrcpyParamsToArgs(params map[string]string) []string {
 		"audio_bit_rate",
 		"audio_codec_options",
 		"control",
+		"tunnel_forward",
 		"new_display",
 		"max_size",
 		"log_level",
@@ -66,66 +49,4 @@ func toScrcpyCommand(options map[string]string) string {
 		classpath, version)
 	args := scrcpyParamsToArgs(options)
 	return strings.Join(append([]string{base}, args...), " ")
-}
-
-// Global ADB Helper Functions
-
-// GetConnectedDevices returns a list of connected device serials/IPs
-func GetConnectedDevices() ([]string, error) {
-	adbPath, err := utils.GetADBPath()
-	if err != nil {
-		return nil, err
-	}
-	cmd := exec.Command(adbPath, "devices")
-	output, err := cmd.Output()
-	if err != nil {
-		return nil, err
-	}
-
-	var devices []string
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "List of devices attached") {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) >= 2 && parts[1] == "device" {
-			devices = append(devices, parts[0])
-		}
-	}
-	return devices, nil
-}
-
-// ConnectDevice connects to a device via TCP/IP
-func ConnectDevice(address string) error {
-	adbPath, err := utils.GetADBPath()
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(adbPath, "connect", address)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("adb connect failed: %v, output: %s", err, string(output))
-	}
-	if strings.Contains(string(output), "unable to connect") || strings.Contains(string(output), "failed to connect") {
-		return fmt.Errorf("adb connect failed: %s", string(output))
-	}
-	return nil
-}
-
-// PairDevice pairs with a device using a pairing code
-func PairDevice(address, code string) error {
-	adbPath, err := utils.GetADBPath()
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(adbPath, "pair", address, code)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("adb pair failed: %v, output: %s", err, string(output))
-	}
-	if !strings.Contains(string(output), "Successfully paired") {
-		return fmt.Errorf("adb pair failed: %s", string(output))
-	}
-	return nil
 }

--- a/sdriver/scrcpy/driver.go
+++ b/sdriver/scrcpy/driver.go
@@ -65,6 +65,12 @@ type ScrcpyDriver struct {
 	LastIDRRequestTime time.Time
 }
 
+func setDefault(config map[string]string, key string, value string) {
+	if strings.TrimSpace(config[key]) == "" {
+		config[key] = value
+	}
+}
+
 // 一个ScrcpyDriver对应一个scrcpy实例，通过本地端口建立三个连接：视频、音频、控制
 func New(config map[string]string) (*ScrcpyDriver, error) {
 	var err error
@@ -98,15 +104,22 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 	}
 
 	localPort := SCRCPY_PROXY_PORT_DEFAULT
+	remoteADBDirect := da.adbClient.transportErr == nil &&
+		da.adbClient.transport != nil &&
+		da.adbClient.transport.Capabilities().SupportsDirectAbs
 
-	da.adbClient.ReverseRemove(fmt.Sprintf("localabstract:scrcpy_%s", da.scid))
-	err = da.adbClient.Reverse(fmt.Sprintf("localabstract:scrcpy_%s", da.scid), "tcp:"+localPort)
-	if err != nil {
-		log.Printf("[scrcpy] Set up reverse tunnel failed: %v", err)
-		// listener.Close()
-		return nil, err
+	if remoteADBDirect {
+		log.Printf("[scrcpy] using remote adb direct socket mode for localabstract:scrcpy_%s", da.scid)
+	} else {
+		da.adbClient.ReverseRemove(fmt.Sprintf("localabstract:scrcpy_%s", da.scid))
+		err = da.adbClient.Reverse(fmt.Sprintf("localabstract:scrcpy_%s", da.scid), "tcp:"+localPort)
+		if err != nil {
+			log.Printf("[scrcpy] Set up reverse tunnel failed: %v", err)
+			// listener.Close()
+			return nil, err
+		}
+		log.Printf("[scrcpy] set up reverse tunnel success: localabstract:scrcpy_%s -> tcp:%s", da.scid, localPort)
 	}
-	log.Printf("[scrcpy] set up reverse tunnel success: localabstract:scrcpy_%s -> tcp:%s", da.scid, localPort)
 
 	if !da.adbClient.SupportOpusAudio() {
 		config["audio"] = "false"
@@ -119,13 +132,23 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 		return nil, err
 	}
 	os.Remove(SCRCPY_SERVER_LOCAL_PATH)
-	listener, err := net.Listen("tcp", ":"+localPort)
-	if err != nil {
-		log.Printf("[scrcpy] Listen port failed: %v", err)
-		return nil, err
+	var listener net.Listener
+	if !remoteADBDirect {
+		listener, err = net.Listen("tcp", ":"+localPort)
+		if err != nil {
+			log.Printf("[scrcpy] Listen port failed: %v", err)
+			return nil, err
+		}
 	}
 	// da.adbClient.cancel()
 	log.Printf("[scrcpy] driver config: %v", config)
+	setDefault(config, "audio", "false")
+	setDefault(config, "control", "true")
+	setDefault(config, "video_codec", "h264")
+	setDefault(config, "video_bit_rate", "8M")
+	setDefault(config, "max_size", "1280")
+	setDefault(config, "max_fps", "60")
+
 	video_codec_options := ""
 	max_size, err := strconv.Atoi(config["max_size"])
 	if err != nil {
@@ -135,10 +158,7 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 	if err != nil {
 		max_fps = 120
 	}
-	video_bit_rate_str, ok := config["video_bit_rate"]
-	if !ok || video_bit_rate_str == "" {
-		config["video_bit_rate"] = "4M" // 默认 4 Mbps
-	}
+	video_bit_rate_str := config["video_bit_rate"]
 	video_bit_rate, err := utils.ParseBitrate(video_bit_rate_str)
 	if err != nil {
 		return nil, fmt.Errorf("invalid video bit rate: %v", err)
@@ -289,6 +309,9 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 
 		"video_encoder": config["video_encoder"],
 	}
+	if remoteADBDirect {
+		options["tunnel_forward"] = "true"
+	}
 	if config["video_encoder"] != "" {
 		options["video_encoder"] = config["video_encoder"]
 		log.Printf("Using user-specified video encoder: %s", config["video_encoder"])
@@ -305,6 +328,14 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 	da.options = options
 	// log.Println("Scrcpy server started successfully")
 	// conns := make([]net.Conn, 3)
+
+	if remoteADBDirect {
+		if err := da.connectRemoteADBSockets(options); err != nil {
+			return nil, err
+		}
+		return da, nil
+	}
+
 	log.Println("start tcp listening")
 
 	// 设置一个总的超时时间，如果在这个时间内没有建立所有连接，就认为失败
@@ -374,6 +405,87 @@ func New(config map[string]string) (*ScrcpyDriver, error) {
 func (da *ScrcpyDriver) ShowDeviceInfo() {
 	log.Printf("[scrcpy] Device Name: %s", da.deviceName)
 	log.Printf("[scrcpy] media Meta: %v", da.mediaMeta)
+}
+
+func (da *ScrcpyDriver) connectRemoteADBSockets(options map[string]string) error {
+	socketName := fmt.Sprintf("scrcpy_%s", da.scid)
+	connect := func(label string) (net.Conn, error) {
+		conn, err := da.adbClient.ConnectLocalAbstractWithRetry(socketName, 12*time.Second)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connect remote adb %s socket: %v", label, err)
+		}
+		return conn, nil
+	}
+
+	var firstConn net.Conn
+	var videoConn net.Conn
+	var audioConn net.Conn
+	var controlConn net.Conn
+
+	if options["video"] == "true" {
+		conn, err := connect("video")
+		if err != nil {
+			return err
+		}
+		videoConn = conn
+		if firstConn == nil {
+			firstConn = conn
+		}
+	}
+	if options["audio"] == "true" {
+		conn, err := connect("audio")
+		if err != nil {
+			return err
+		}
+		audioConn = conn
+		if firstConn == nil {
+			firstConn = conn
+		}
+	}
+	if options["control"] == "true" {
+		conn, err := connect("control")
+		if err != nil {
+			return err
+		}
+		controlConn = conn
+		if firstConn == nil {
+			firstConn = conn
+		}
+	}
+
+	if firstConn == nil {
+		return fmt.Errorf("no scrcpy sockets enabled")
+	}
+
+	dummy := make([]byte, 1)
+	if _, err := io.ReadFull(firstConn, dummy); err != nil {
+		return fmt.Errorf("failed to read scrcpy forward dummy byte: %v", err)
+	}
+	if err := da.readDeviceMeta(firstConn); err != nil {
+		return fmt.Errorf("failed to read device metadata: %v", err)
+	}
+	log.Printf("[scrcpy] Connected Device: %s", da.deviceName)
+
+	if videoConn != nil {
+		if err := da.assignConn(videoConn); err != nil {
+			videoConn.Close()
+			return err
+		}
+	}
+	if audioConn != nil {
+		if err := da.assignConn(audioConn); err != nil {
+			audioConn.Close()
+			return err
+		}
+	}
+	if controlConn != nil {
+		da.controlConn = controlConn
+		da.capabilities.CanControl = true
+		da.capabilities.CanUHID = true
+		da.capabilities.CanClipboard = true
+		log.Println("Scrcpy Control Connection Established")
+	}
+	return nil
 }
 
 func (da *ScrcpyDriver) EncoderList() []string {

--- a/sdriver/scrcpy/local_adb_transport.go
+++ b/sdriver/scrcpy/local_adb_transport.go
@@ -1,0 +1,120 @@
+package scrcpy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"webscreen/sdriver"
+	"webscreen/utils"
+)
+
+type LocalADBTransport struct {
+	ADBExecutable string
+}
+
+func NewLocalADBTransport(adbExecutable ...string) (*LocalADBTransport, error) {
+	executable := ""
+	if len(adbExecutable) > 0 {
+		executable = adbExecutable[0]
+	}
+	if executable == "" {
+		var err error
+		executable, err = utils.GetADBPath()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &LocalADBTransport{ADBExecutable: executable}, nil
+}
+
+func (t *LocalADBTransport) Devices(ctx context.Context) ([]DeviceDescriptor, error) {
+	output, err := runADBCommand(ctx, t.ADBExecutable, "devices", "-l")
+	if err != nil {
+		return nil, err
+	}
+	return parseADBDevices(output, sdriver.TransportLocalADB, ""), nil
+}
+
+func (t *LocalADBTransport) Shell(ctx context.Context, serial string, argv ...string) ([]byte, error) {
+	args := appendSerial(nil, serial)
+	args = append(args, "shell")
+	args = append(args, argv...)
+	return runADBCommand(ctx, t.ADBExecutable, args...)
+}
+
+func (t *LocalADBTransport) Push(ctx context.Context, serial, src, dst string) error {
+	args := appendSerial(nil, serial)
+	args = append(args, "push", src, dst)
+	_, err := runADBCommand(ctx, t.ADBExecutable, args...)
+	return err
+}
+
+func (t *LocalADBTransport) Reverse(ctx context.Context, serial, remote, local string) error {
+	args := appendSerial(nil, serial)
+	args = append(args, "reverse", remote, local)
+	_, err := runADBCommand(ctx, t.ADBExecutable, args...)
+	return err
+}
+
+func (t *LocalADBTransport) ReverseRemove(ctx context.Context, serial, remote string) error {
+	args := appendSerial(nil, serial)
+	args = append(args, "reverse", "--remove", remote)
+	_, err := runADBCommand(ctx, t.ADBExecutable, args...)
+	return err
+}
+
+func (t *LocalADBTransport) OpenLocalAbstract(ctx context.Context, serial, socketName string) (net.Conn, error) {
+	return nil, ErrCapabilityNotSupported
+}
+
+func (t *LocalADBTransport) Connect(ctx context.Context, addr string) error {
+	output, err := runADBCommand(ctx, t.ADBExecutable, "connect", addr)
+	if err != nil {
+		return err
+	}
+	if adbOutputFailed(output) {
+		return adbOutputError("adb connect failed", output)
+	}
+	return nil
+}
+
+func (t *LocalADBTransport) Pair(ctx context.Context, addr, code string) error {
+	output, err := runADBCommand(ctx, t.ADBExecutable, "pair", addr, code)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(output), "Successfully paired") {
+		return adbOutputError("adb pair failed", output)
+	}
+	return nil
+}
+
+func (t *LocalADBTransport) Capabilities() ADBTransportCaps {
+	return ADBTransportCaps{
+		CanReverse:        true,
+		CanTCPIPConnect:   true,
+		CanPair:           true,
+		SupportsDirectAbs: false,
+	}
+}
+
+func (t *LocalADBTransport) Bridge() sdriver.BridgeID {
+	return ""
+}
+
+func appendSerial(args []string, serial string) []string {
+	if serial == "" {
+		return args
+	}
+	return append(args, "-s", serial)
+}
+
+func adbOutputFailed(output []byte) bool {
+	text := string(output)
+	return strings.Contains(text, "unable to connect") || strings.Contains(text, "failed to connect")
+}
+
+func adbOutputError(prefix string, output []byte) error {
+	return fmt.Errorf("%s: %s", prefix, strings.TrimSpace(string(output)))
+}

--- a/sdriver/scrcpy/remote_adb.go
+++ b/sdriver/scrcpy/remote_adb.go
@@ -1,0 +1,95 @@
+package scrcpy
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func remoteADBEndpoint() (string, int, bool) {
+	if os.Getenv("WEBSCREEN_REMOTE_ADB") != "1" {
+		return "", 0, false
+	}
+
+	host := os.Getenv("WEBSCREEN_REMOTE_ADB_HOST")
+	if host == "" {
+		host = os.Getenv("ANDROID_ADB_SERVER_ADDRESS")
+	}
+
+	portText := os.Getenv("WEBSCREEN_REMOTE_ADB_PORT")
+	if portText == "" {
+		portText = os.Getenv("ANDROID_ADB_SERVER_PORT")
+	}
+	if portText == "" {
+		portText = "5037"
+	}
+
+	port, err := strconv.Atoi(portText)
+	if host == "" || err != nil || port <= 0 {
+		return "", 0, false
+	}
+	return host, port, true
+}
+
+func adbService(conn net.Conn, service string) error {
+	payload := []byte(service)
+	if _, err := fmt.Fprintf(conn, "%04x%s", len(payload), payload); err != nil {
+		return err
+	}
+
+	status := make([]byte, 4)
+	if _, err := io.ReadFull(conn, status); err != nil {
+		return err
+	}
+	switch string(status) {
+	case "OKAY":
+		return nil
+	case "FAIL":
+		sizeBuf := make([]byte, 4)
+		if _, err := io.ReadFull(conn, sizeBuf); err != nil {
+			return err
+		}
+		size64, err := strconv.ParseInt(string(sizeBuf), 16, 32)
+		if err != nil {
+			return err
+		}
+		message := make([]byte, int(size64))
+		if _, err := io.ReadFull(conn, message); err != nil {
+			return err
+		}
+		return fmt.Errorf("adb service %q failed: %s", service, strings.TrimSpace(string(message)))
+	default:
+		return fmt.Errorf("adb service %q returned unexpected status %q", service, status)
+	}
+}
+
+func (c *ADBClient) ConnectLocalAbstract(socketName string) (net.Conn, error) {
+	if c.transportErr != nil {
+		return nil, c.transportErr
+	}
+	if c.transport == nil {
+		return nil, fmt.Errorf("adb transport is not configured")
+	}
+	if c.deviceSerial == "" {
+		return nil, fmt.Errorf("device serial is required for remote adb direct socket")
+	}
+	return c.transport.OpenLocalAbstract(c.ctx, c.deviceSerial, socketName)
+}
+
+func (c *ADBClient) ConnectLocalAbstractWithRetry(socketName string, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := c.ConnectLocalAbstract(socketName)
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, lastErr
+}

--- a/sdriver/scrcpy/remote_adb_transport.go
+++ b/sdriver/scrcpy/remote_adb_transport.go
@@ -1,0 +1,128 @@
+package scrcpy
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+	"webscreen/sdriver"
+)
+
+type RemoteADBTransport struct {
+	BridgeID      sdriver.BridgeID
+	Host          string
+	Port          int
+	ADBExecutable string
+}
+
+func NewRemoteADBTransport(bridgeID sdriver.BridgeID, host string, port int, adbExecutable string) (*RemoteADBTransport, error) {
+	if strings.TrimSpace(adbExecutable) == "" {
+		return nil, ErrADBExecutableRequired
+	}
+	if strings.TrimSpace(host) == "" || port <= 0 {
+		return nil, fmt.Errorf("invalid remote adb endpoint")
+	}
+	if bridgeID == "" {
+		bridgeID = "bootstrap-env"
+	}
+	return &RemoteADBTransport{
+		BridgeID:      bridgeID,
+		Host:          host,
+		Port:          port,
+		ADBExecutable: adbExecutable,
+	}, nil
+}
+
+func (t *RemoteADBTransport) Devices(ctx context.Context) ([]DeviceDescriptor, error) {
+	output, err := runADBCommand(ctx, t.ADBExecutable, t.prefixArgs("devices", "-l")...)
+	if err != nil {
+		return nil, err
+	}
+	return parseADBDevices(output, sdriver.TransportRemoteADB, t.BridgeID), nil
+}
+
+func (t *RemoteADBTransport) Shell(ctx context.Context, serial string, argv ...string) ([]byte, error) {
+	args := t.prefixArgs()
+	args = appendSerial(args, serial)
+	args = append(args, "shell")
+	args = append(args, argv...)
+	return runADBCommand(ctx, t.ADBExecutable, args...)
+}
+
+func (t *RemoteADBTransport) Push(ctx context.Context, serial, src, dst string) error {
+	args := t.prefixArgs()
+	args = appendSerial(args, serial)
+	args = append(args, "push", src, dst)
+	_, err := runADBCommand(ctx, t.ADBExecutable, args...)
+	return err
+}
+
+func (t *RemoteADBTransport) Reverse(ctx context.Context, serial, remote, local string) error {
+	return ErrCapabilityNotSupported
+}
+
+func (t *RemoteADBTransport) ReverseRemove(ctx context.Context, serial, remote string) error {
+	return ErrCapabilityNotSupported
+}
+
+func (t *RemoteADBTransport) OpenLocalAbstract(ctx context.Context, serial, socketName string) (net.Conn, error) {
+	if serial == "" {
+		return nil, fmt.Errorf("device serial is required for remote adb direct socket")
+	}
+	dialer := net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(t.Host, strconv.Itoa(t.Port)))
+	if err != nil {
+		return nil, err
+	}
+	if err := adbService(conn, "host:transport:"+serial); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if err := adbService(conn, "localabstract:"+socketName); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (t *RemoteADBTransport) Connect(ctx context.Context, addr string) error {
+	output, err := runADBCommand(ctx, t.ADBExecutable, t.prefixArgs("connect", addr)...)
+	if err != nil {
+		return err
+	}
+	if adbOutputFailed(output) {
+		return adbOutputError("adb connect failed", output)
+	}
+	return nil
+}
+
+func (t *RemoteADBTransport) Pair(ctx context.Context, addr, code string) error {
+	output, err := runADBCommand(ctx, t.ADBExecutable, t.prefixArgs("pair", addr, code)...)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(output), "Successfully paired") {
+		return adbOutputError("adb pair failed", output)
+	}
+	return nil
+}
+
+func (t *RemoteADBTransport) Capabilities() ADBTransportCaps {
+	return ADBTransportCaps{
+		CanReverse:        false,
+		CanTCPIPConnect:   true,
+		CanPair:           true,
+		SupportsDirectAbs: true,
+	}
+}
+
+func (t *RemoteADBTransport) Bridge() sdriver.BridgeID {
+	return t.BridgeID
+}
+
+func (t *RemoteADBTransport) prefixArgs(args ...string) []string {
+	prefix := []string{"-H", t.Host, "-P", strconv.Itoa(t.Port)}
+	return append(prefix, args...)
+}

--- a/sdriver/scrcpy/remote_adb_transport_test.go
+++ b/sdriver/scrcpy/remote_adb_transport_test.go
@@ -1,0 +1,86 @@
+package scrcpy
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"webscreen/sdriver"
+)
+
+func TestRemoteADBTransportOpenLocalAbstractUsesRawADBProtocol(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	services := make(chan string, 2)
+	payload := make(chan []byte, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		for i := 0; i < 2; i++ {
+			service, err := readFakeADBService(reader)
+			if err != nil {
+				return
+			}
+			services <- service
+			_, _ = conn.Write([]byte("OKAY"))
+		}
+		buf := make([]byte, 5)
+		_, _ = io.ReadFull(reader, buf)
+		payload <- buf
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	transport, err := NewRemoteADBTransport(sdriver.BridgeID("mac-coral"), addr.IP.String(), addr.Port, "/fake/adb")
+	if err != nil {
+		t.Fatalf("NewRemoteADBTransport returned error: %v", err)
+	}
+	conn, err := transport.OpenLocalAbstract(context.Background(), "5f9e7947", "scrcpy_AB12CD34")
+	if err != nil {
+		t.Fatalf("OpenLocalAbstract returned error: %v", err)
+	}
+	_, _ = conn.Write([]byte("hello"))
+	_ = conn.Close()
+
+	gotTransport := <-services
+	gotSocket := <-services
+	if gotTransport != "host:transport:5f9e7947" {
+		t.Fatalf("transport service = %q", gotTransport)
+	}
+	if gotSocket != "localabstract:scrcpy_AB12CD34" {
+		t.Fatalf("socket service = %q", gotSocket)
+	}
+	if string(<-payload) != "hello" {
+		t.Fatalf("payload was not forwarded")
+	}
+}
+
+func readFakeADBService(r *bufio.Reader) (string, error) {
+	sizeBytes := make([]byte, 4)
+	if _, err := io.ReadFull(r, sizeBytes); err != nil {
+		return "", err
+	}
+	size64, err := strconv.ParseInt(string(sizeBytes), 16, 32)
+	if err != nil {
+		return "", err
+	}
+	if size64 <= 0 {
+		return "", fmt.Errorf("invalid service size %d", size64)
+	}
+	payload := make([]byte, int(size64))
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(payload)), nil
+}

--- a/sdriver/scrcpy/structs.go
+++ b/sdriver/scrcpy/structs.go
@@ -1,6 +1,7 @@
 package scrcpy
 
 type ScrcpyOptions struct {
+	SCID         string `json:"scid"`
 	Version      string `json:"version"`
 	MaxSize      string `json:"max_size"`
 	MaxFPS       string `json:"max_fps"`
@@ -9,6 +10,10 @@ type ScrcpyOptions struct {
 	VideoCodec        string `json:"video_codec"`
 	VideoCodecOptions string `json:"video_codec_options"`
 	NewDisplay        string `json:"new_display"`
+	Video             bool   `json:"video"`
+	Audio             bool   `json:"audio"`
+	Control           bool   `json:"control"`
+	TunnelForward     bool   `json:"tunnel_forward"`
 }
 
 // type ConnectOptions struct {

--- a/sdriver/scrcpy/transport.go
+++ b/sdriver/scrcpy/transport.go
@@ -1,0 +1,73 @@
+package scrcpy
+
+import (
+	"context"
+	"errors"
+	"net"
+	"webscreen/sdriver"
+)
+
+var (
+	ErrADBExecutableRequired  = errors.New("adb executable is required")
+	ErrCapabilityNotSupported = errors.New("transport capability is not supported")
+	ErrSCIDRequired           = errors.New("scrcpy scid is required")
+)
+
+type DeviceStatus string
+
+const (
+	DeviceConnected    DeviceStatus = "connected"
+	DeviceUnauthorized DeviceStatus = "unauthorized"
+	DeviceOffline      DeviceStatus = "offline"
+	DeviceUnknown      DeviceStatus = "unknown"
+)
+
+type DeviceDescriptor struct {
+	Ref       sdriver.DeviceRef
+	Serial    string
+	Model     string
+	Status    DeviceStatus
+	Transport sdriver.TransportID
+	BridgeID  sdriver.BridgeID
+}
+
+type DeviceProvider interface {
+	Devices(ctx context.Context) ([]DeviceDescriptor, error)
+}
+
+type ADBTransport interface {
+	DeviceProvider
+
+	Shell(ctx context.Context, serial string, argv ...string) ([]byte, error)
+	Push(ctx context.Context, serial, src, dst string) error
+	Reverse(ctx context.Context, serial, remote, local string) error
+	ReverseRemove(ctx context.Context, serial, remote string) error
+	OpenLocalAbstract(ctx context.Context, serial, socketName string) (net.Conn, error)
+	Connect(ctx context.Context, addr string) error
+	Pair(ctx context.Context, addr, code string) error
+
+	Capabilities() ADBTransportCaps
+	Bridge() sdriver.BridgeID
+}
+
+type ADBTransportCaps struct {
+	CanReverse        bool
+	CanTCPIPConnect   bool
+	CanPair           bool
+	SupportsDirectAbs bool
+}
+
+type ScrcpyTransport interface {
+	DeviceProvider
+
+	StartScrcpySession(ctx context.Context, ref sdriver.DeviceRef, opts ScrcpyOptions) (*ScrcpySession, error)
+}
+
+type ScrcpySession struct {
+	SCID              string
+	Video             net.Conn
+	Audio             net.Conn
+	Control           net.Conn
+	NeedsForwardDummy bool
+	Close             func() error
+}

--- a/sdriver/scrcpy/transport_contract_test.go
+++ b/sdriver/scrcpy/transport_contract_test.go
@@ -1,0 +1,45 @@
+package scrcpy
+
+import (
+	"context"
+	"net"
+	"webscreen/sdriver"
+)
+
+type contractADBTransport struct{}
+
+var _ ADBTransport = (*contractADBTransport)(nil)
+
+func (contractADBTransport) Devices(context.Context) ([]DeviceDescriptor, error) { return nil, nil }
+func (contractADBTransport) Shell(context.Context, string, ...string) ([]byte, error) {
+	return nil, nil
+}
+func (contractADBTransport) Push(context.Context, string, string, string) error { return nil }
+func (contractADBTransport) Reverse(context.Context, string, string, string) error {
+	return nil
+}
+func (contractADBTransport) ReverseRemove(context.Context, string, string) error { return nil }
+func (contractADBTransport) OpenLocalAbstract(context.Context, string, string) (net.Conn, error) {
+	return nil, nil
+}
+func (contractADBTransport) Connect(context.Context, string) error      { return nil }
+func (contractADBTransport) Pair(context.Context, string, string) error { return nil }
+func (contractADBTransport) Capabilities() ADBTransportCaps             { return ADBTransportCaps{} }
+func (contractADBTransport) Bridge() sdriver.BridgeID                   { return "" }
+func (contractADBTransport) StartScrcpySession(context.Context, sdriver.DeviceRef, ScrcpyOptions) (*ScrcpySession, error) {
+	return nil, nil
+}
+
+type contractRootAgentScrcpyTransport struct{}
+
+var (
+	_ DeviceProvider  = (*contractRootAgentScrcpyTransport)(nil)
+	_ ScrcpyTransport = (*contractRootAgentScrcpyTransport)(nil)
+)
+
+func (contractRootAgentScrcpyTransport) Devices(context.Context) ([]DeviceDescriptor, error) {
+	return nil, nil
+}
+func (contractRootAgentScrcpyTransport) StartScrcpySession(context.Context, sdriver.DeviceRef, ScrcpyOptions) (*ScrcpySession, error) {
+	return nil, nil
+}

--- a/webservice/android/connect.go
+++ b/webservice/android/connect.go
@@ -1,96 +1,42 @@
 package android
 
 import (
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-	"webscreen/utils"
+	"context"
+	"webscreen/sdriver/scrcpy"
 )
 
-func ExecADB(args ...string) error {
-	adbPath, err := utils.GetADBPath()
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(adbPath, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-// GetDevices returns a list of connected devices
 func GetDevices() ([]AndroidDevice, error) {
-	adbPath, err := utils.GetADBPath()
+	transport, err := scrcpy.NewLocalADBTransport()
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command(adbPath, "devices")
-	output, err := cmd.Output()
+	devices, err := transport.Devices(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	var adbDevices []AndroidDevice
-	lines := strings.Split(string(output), "\n")
-	for _, line := range lines {
-		if strings.TrimSpace(line) == "" || strings.HasPrefix(line, "List of devices attached") {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			switch parts[1] {
-			case "device":
-				adbDevices = append(adbDevices, AndroidDevice{
-					DeviceID: parts[0],
-					Status:   "connected",
-				})
-			case "offline":
-				adbDevices = append(adbDevices, AndroidDevice{
-					DeviceID: parts[0],
-					Status:   "offline",
-				})
-			case "unauthorized":
-				adbDevices = append(adbDevices, AndroidDevice{
-					DeviceID: parts[0],
-					Status:   "unauthorized",
-				})
-			}
-		}
+	adbDevices := make([]AndroidDevice, 0, len(devices))
+	for _, device := range devices {
+		adbDevices = append(adbDevices, AndroidDevice{
+			DeviceID: device.Serial,
+			Status:   string(device.Status),
+		})
 	}
 	return adbDevices, nil
 }
 
-// ConnectDevice connects to a device via TCP/IP
 func ConnectDevice(address string) error {
-	adbPath, err := utils.GetADBPath()
+	transport, err := scrcpy.NewLocalADBTransport()
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(adbPath, "connect", address)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("adb connect failed: %v, output: %s", err, string(output))
-	}
-	if strings.Contains(string(output), "unable to connect") || strings.Contains(string(output), "failed to connect") {
-		return fmt.Errorf("adb connect failed: %s", string(output))
-	}
-	return nil
+	return transport.Connect(context.Background(), address)
 }
 
-// PairDevice pairs with a device using a pairing code
 func PairDevice(address, code string) error {
-	adbPath, err := utils.GetADBPath()
+	transport, err := scrcpy.NewLocalADBTransport()
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(adbPath, "pair", address, code)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("adb pair failed: %v, output: %s", err, string(output))
-	}
-	if !strings.Contains(string(output), "Successfully paired") {
-		return fmt.Errorf("adb pair failed: %s", string(output))
-	}
-	return nil
+	return transport.Pair(context.Background(), address, code)
 }


### PR DESCRIPTION
## Summary

Phase 0a of the `device-transport-refactor` OpenSpec change. Lays the foundation for multi-bridge / multi-device support by introducing three new abstractions and collapsing all scattered ADB calls into them. **Pure refactor — no runtime behavior changes**.

See [`openspec/changes/device-transport-refactor/`](openspec/changes/device-transport-refactor/) for the full proposal, design, tasks and TDD.

## What's in

**New interfaces** (`sdriver/scrcpy/transport.go`) — three-way split, deliberately not inheriting each other:

- `DeviceProvider` — list devices.
- `ADBTransport` — extends `DeviceProvider`, adds `Shell` / `Push` / `Reverse` / `OpenLocalAbstract` / `Connect` / `Pair`. **Only** local / remote-adb transports implement this. Root-agent (a future change) **cannot** implement `ADBTransport` — it has no arbitrary shell / push / pair / connect surface.
- `ScrcpyTransport` — `StartScrcpySession(...)` returning `ScrcpySession{Video, Audio, Control, NeedsForwardDummy}`. Adapter for ADB-based transports lives in `adb_scrcpy_transport.go`.

**DeviceRef v1** (`sdriver/device_ref.go`) — stable opaque key for cross-layer routing:

- Format: \`v1.<base64url(json)>\` with sorted JSON keys.
- Legacy bare ADB serial → upgraded to \`DeviceRef{Transport: local_adb, Serial: <legacy>}\` with warn log.
- Allows \`:\` for Wi-Fi ADB serials (\`192.168.1.100:5555\`), rejects \`/\`, \`|\`, whitespace, control chars.
- Decode of unknown version (\`v2.…\`) returns \`ErrUnknownDeviceRefVersion\`, never silent fallback.

**Two `ADBTransport` implementations**:

- \`LocalADBTransport\` — injects \`ADBExecutable\` from \`utils.GetADBPath()\` once at construction; CLI ops go through \`exec(ADBExecutable, ...)\`.
- \`RemoteADBTransport\` — constructor requires explicit \`host, port, adbExecutable\`; does **not** call \`GetADBPath\`. CLI ops prepend \`-H host -P port\`. Only \`OpenLocalAbstract\` walks the raw ADB host protocol socket — the rest of the surface is plain \`adb\` CLI.

**12 scattered ADB call sites collapsed** into the transport layer:

- \`webservice/android/connect.go\` (\`GetDevices\`, \`ConnectDevice\`, \`PairDevice\`, \`ExecADB\`) → wired through transport.
- \`sdriver/scrcpy/adb.go:122,159\` — removed hardcoded \`\"adb\"\` string that bypassed \`GetADBPath\` and caused mis-routing when a remote bridge was active.
- \`sdriver/scrcpy/adbutils.go\` — removed \`ConnectDevice\` / \`PairDevice\` / \`GetConnectedDevices\` (duplicates of \`webservice/android\`).
- \`sdriver/scrcpy/adb_transport_exec.go\` + \`adb_transport_factory.go\` — single \`execADB\` helper and factory.

**Audit gate**: no \`exec.Command(.., \"adb\")\` strings remain in business code outside transport implementations.

## What's deliberately NOT in (later Phases)

- scrcpy driver concurrency (scid / tmpDir / dynamic port) — Phase 0b.
- WebSocket \`CheckOrigin\` whitelist / audit log / 5s timeout / \`GetADBPath\` download path move — Phase 0c.
- Frontend \`device_ref\` field plumbing + \`webscreen_device_configs\` localStorage migration — Phase 0d.
- Bridge registry + API + health probe + UI — Phase 1a–1d.
- Root-agent transport — covered by the separate \`webscreen-root-agent\` OpenSpec change.

## Design gates (from review)

| # | Gate | Enforced by |
|---|---|---|
| 1 | RootAgentTransport must NOT implement ADBTransport | Compile-time assertion on transport impls; ADBTransport surface excludes any subset that root-agent could safely expose |
| 2 | socat compat: token doesn't protect socat | Bridge work is later phases; this PR only ensures \`ADBTransport\` interface signature accepts neither token nor security_mode — those are bridge-layer concerns |
| 3 | Health probe must not use OpenLocalAbstract | Phase 1c concern; this PR keeps \`OpenLocalAbstract\` as a private mechanic of \`RemoteADBTransport\` |
| 4 | DeviceRef versioned, legacy upgradable, display ≠ key | \`device_ref.go\` + \`device_ref_test.go\` enforce v1 format, sorted keys, legacy upgrade, character allowlist (allows \`:\` for wifi adb), strict version reject |

## Test plan

Run on \`phase-0a/transport-interface\`:

\`\`\`
go test \$(go list ./... | grep -v linuxRecorder)
\`\`\`

(Excluding \`linuxRecorder\` — its \`bendahl/uinput\` dep uses Linux-only \`syscall.SYS_IOCTL\` and cannot compile on Windows. This failure exists identically on \`main\`; not a regression introduced by this PR.)

Result: **13/13 PASS** in 0.04s on Windows + Go 1.25.4.

Tests covering the four gates:

- \`TestDeviceRefFixtureRoundTrips\` (3 sub-fixtures: local / remote / root-agent)
- \`TestDeviceRefRoundTripRemoteADB\`
- \`TestDeviceRefJSONFieldOrder\`
- \`TestDeviceRefLegacySerialAllowsWifiADBColon\`
- \`TestDeviceRefRejectsUnknownVersion\`
- \`TestDeviceRefRejectsInvalidLegacySerial\` (4 sub-cases: \`/\`, \`|\`, space, \`\\x7f\`)
- \`TestParseADBDevicesLocal\`
- \`TestParseADBDevicesRemoteBridgeID\`
- \`TestLocalADBTransportShellRoutesSerial\`
- \`TestRemoteADBTransportPrefixesHostPortForCLI\`
- \`TestRemoteADBTransportRequiresExplicitADBExecutable\`
- \`TestADBExecHelper\`
- \`TestRemoteADBTransportOpenLocalAbstractUsesRawADBProtocol\`

Manual regression: existing launcher's env-var startup (\`WEBSCREEN_REMOTE_ADB=1 + HOST + PORT\`) keeps working — those env vars still register through the transport factory; later phases move them to an explicit bootstrap bridge registry entry.

## File layout

\`\`\`
27 files changed, +2688, -246

new:
  sdriver/device_ref.go                          (+116)
  sdriver/device_ref_test.go                     (+105)
  sdriver/scrcpy/transport.go                    (+73)
  sdriver/scrcpy/transport_contract_test.go      (+45)
  sdriver/scrcpy/local_adb_transport.go          (+120)
  sdriver/scrcpy/remote_adb_transport.go         (+128)
  sdriver/scrcpy/remote_adb_transport_test.go    (+86)
  sdriver/scrcpy/adb_scrcpy_transport.go         (+25)
  sdriver/scrcpy/adb_transport_exec.go           (+22)
  sdriver/scrcpy/adb_transport_exec_test.go      (+109)
  sdriver/scrcpy/adb_transport_factory.go        (+15)
  sdriver/scrcpy/adb_devices_parse.go            (+64)
  sdriver/scrcpy/adb_devices_parse_test.go       (+39)
  sdriver/scrcpy/remote_adb.go                   (+95, refactored)
  openspec/changes/device-transport-refactor/    proposal / design / tasks / tdd / SEAM
  fixtures/device_ref/*.json                     (3 round-trip fixtures)

refactored:
  sdriver/scrcpy/adb.go            (collapsed hardcoded "adb" -> transport)
  sdriver/scrcpy/adbutils.go       (removed duplicate ConnectDevice/PairDevice)
  sdriver/scrcpy/driver.go         (transport injection)
  webservice/android/connect.go    (all 4 funcs route through transport)
  sdriver/scrcpy/structs.go        (+5)
\`\`\`